### PR TITLE
Add repeats for useradd command on shared host provision

### DIFF
--- a/deploy/operator/provision-shared-host.yaml
+++ b/deploy/operator/provision-shared-host.yaml
@@ -58,7 +58,11 @@ spec:
         cat >script.sh <<EOF
         sudo dnf install podman -y
         rm -f $USERNAME $USERNAME.pub
-        sudo useradd -m $USERNAME -p $(openssl rand -base64 12)
+        # sometimes it hits  "useradd: cannot lock /etc/passwd; try again later" error, so need to repeat
+        for i in {10..1}; do
+          sudo useradd -m $USERNAME -p $(openssl rand -base64 12) && break
+          sleep 1
+        done
         ssh-keygen -N '' -f $USERNAME
         sudo su $USERNAME -c 'mkdir /home/$USERNAME/.ssh'
         sudo su $USERNAME -c 'mkdir /home/$USERNAME/build'


### PR DESCRIPTION
Sometimes on shared servers there is a possible conflict adding/removing the users, so  some operations getting 
`useradd: cannot lock /etc/passwd; try again later` error.   This PR adds some retires to the operation.

Jira bug https://issues.redhat.com/browse/KFLUXBUGS-1532