### PR TITLE
chore[KFLUXINFRA-866] Add default tags to MPC VM(s)

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -21,6 +21,15 @@ import (
 
 const MultiPlatformManaged = "MultiPlatformManaged"
 
+var defaultInstanceTags = []types.Tag{
+	{Key: aws.String("Project"), Value: aws.String("Konflux")},
+	{Key: aws.String("Owner"), Value: aws.String("konflux-infra@redhat.com")},
+	{Key: aws.String("ManagedBy"), Value: aws.String("Konflux Infra Team")},
+	{Key: aws.String("app-code"), Value: aws.String("ASSH-001")},
+	{Key: aws.String("service-phase"), Value: aws.String("Production")},
+	{Key: aws.String("cost-center"), Value: aws.String("670")},
+}
+
 func Ec2Provider(platformName string, config map[string]string, systemNamespace string) cloud.CloudProvider {
 	disk, err := strconv.Atoi(config["dynamic."+platformName+".disk"])
 	if err != nil {
@@ -106,6 +115,12 @@ func (r AwsDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.C
 		}
 	}
 
+	instanceTags := []types.Tag{
+		{Key: aws.String(MultiPlatformManaged), Value: aws.String("true")},
+		{Key: aws.String(cloud.InstanceTag), Value: aws.String(instanceTag)},
+		{Key: aws.String("Name"), Value: aws.String("multi-platform-builder-" + name)},
+	}
+
 	launchInput := &ec2.RunInstancesInput{
 		KeyName:            aws.String(r.KeyName),
 		ImageId:            aws.String(r.Ami), //ARM RHEL
@@ -124,7 +139,7 @@ func (r AwsDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.C
 			Ebs:         &types.EbsBlockDevice{DeleteOnTermination: aws.Bool(true), VolumeSize: aws.Int32(r.Disk), VolumeType: types.VolumeTypeGp3, Iops: r.Iops, Throughput: r.Throughput},
 		}},
 		InstanceInitiatedShutdownBehavior: types.ShutdownBehaviorTerminate,
-		TagSpecifications:                 []types.TagSpecification{{ResourceType: types.ResourceTypeInstance, Tags: []types.Tag{{Key: aws.String(MultiPlatformManaged), Value: aws.String("true")}, {Key: aws.String(cloud.InstanceTag), Value: aws.String(instanceTag)}, {Key: aws.String("Name"), Value: aws.String("multi-platform-builder-" + name)}}}},
+		TagSpecifications:                 []types.TagSpecification{{ResourceType: types.ResourceTypeInstance, Tags: append(instanceTags, defaultInstanceTags...)}},
 	}
 	spotInstanceRequested := r.SpotInstancePrice != ""
 	if spotInstanceRequested {

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -9,7 +9,7 @@ import (
 const InstanceTag = "multi-platform-instance"
 
 type CloudProvider interface {
-	LaunchInstance(kubeClient client.Client, ctx context.Context, name string, instanceTag string) (InstanceIdentifier, error)
+	LaunchInstance(kubeClient client.Client, ctx context.Context, name string, instanceTag string, additionalInstanceTags map[string]string) (InstanceIdentifier, error)
 	TerminateInstance(kubeClient client.Client, ctx context.Context, instance InstanceIdentifier) error
 	// GetInstanceAddress this only returns an error if it is a permanant error and the host will not ever be available
 	GetInstanceAddress(kubeClient client.Client, ctx context.Context, instanceId InstanceIdentifier) (string, error)

--- a/pkg/ibm/ibmp.go
+++ b/pkg/ibm/ibmp.go
@@ -53,7 +53,7 @@ func IBMPowerProvider(platform string, config map[string]string, systemNamespace
 	}
 }
 
-func (r IBMPowerDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunName string, instanceTag string) (cloud.InstanceIdentifier, error) {
+func (r IBMPowerDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunName string, instanceTag string, _ map[string]string) (cloud.InstanceIdentifier, error) {
 	service, err := r.authenticate(kubeClient, ctx)
 	if err != nil {
 		return "", err

--- a/pkg/ibm/ibmz.go
+++ b/pkg/ibm/ibmz.go
@@ -38,7 +38,7 @@ func IBMZProvider(arch string, config map[string]string, systemNamespace string)
 	}
 }
 
-func (r IBMZDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunName string, instanceTag string) (cloud.InstanceIdentifier, error) {
+func (r IBMZDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunName string, instanceTag string, _ map[string]string) (cloud.InstanceIdentifier, error) {
 	vpcService, err := r.authenticate(kubeClient, ctx)
 	if err != nil {
 		return "", err

--- a/pkg/reconciler/taskrun/dynamic.go
+++ b/pkg/reconciler/taskrun/dynamic.go
@@ -17,12 +17,13 @@ import (
 
 type DynamicResolver struct {
 	cloud.CloudProvider
-	sshSecret    string
-	platform     string
-	maxInstances int
-	instanceTag  string
-	timeout      int64
-	sudoCommands string
+	sshSecret              string
+	platform               string
+	maxInstances           int
+	instanceTag            string
+	timeout                int64
+	sudoCommands           string
+	additionalInstanceTags map[string]string
 }
 
 func (r DynamicResolver) Deallocate(taskRun *ReconcileTaskRun, ctx context.Context, tr *v1.TaskRun, secretName string, selectedHost string) error {
@@ -160,7 +161,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 	tr.Annotations[AllocationStartTimeAnnotation] = strconv.FormatInt(startTime, 10)
 	log.Info(fmt.Sprintf("%d instances are running, creating a new instance", instanceCount))
 	log.Info("attempting to launch a new host for " + tr.Name)
-	instance, err := r.CloudProvider.LaunchInstance(taskRun.client, ctx, tr.Name, r.instanceTag)
+	instance, err := r.CloudProvider.LaunchInstance(taskRun.client, ctx, tr.Name, r.instanceTag, r.additionalInstanceTags)
 
 	if err != nil {
 		launchErr := err

--- a/pkg/reconciler/taskrun/dynamicpool.go
+++ b/pkg/reconciler/taskrun/dynamicpool.go
@@ -15,13 +15,14 @@ import (
 )
 
 type DynamicHostPool struct {
-	cloudProvider cloud.CloudProvider
-	sshSecret     string
-	platform      string
-	maxInstances  int
-	concurrency   int
-	maxAge        time.Duration
-	instanceTag   string
+	cloudProvider          cloud.CloudProvider
+	sshSecret              string
+	platform               string
+	maxInstances           int
+	concurrency            int
+	maxAge                 time.Duration
+	instanceTag            string
+	additionalInstanceTags map[string]string
 }
 
 func (a DynamicHostPool) InstanceTag() string {
@@ -142,7 +143,7 @@ func (a DynamicHostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *
 	// Counter intuitively we don't need the instance id
 	// It will be picked up on the list call
 	log.Info(fmt.Sprintf("launching instance %s", name))
-	inst, err := a.cloudProvider.LaunchInstance(r.client, ctx, name, a.instanceTag)
+	inst, err := a.cloudProvider.LaunchInstance(r.client, ctx, name, a.instanceTag, a.additionalInstanceTags)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -48,6 +48,14 @@ func TestConfigMapParsing(t *testing.T) {
 	g.Expect(config.hosts["host1"].Platform).Should(Equal("linux/arm64"))
 }
 
+func TestConfigMapParsingForLocal(t *testing.T) {
+	g := NewGomegaWithT(t)
+	_, reconciler := setupClientAndReconciler(createLocalHostConfig())
+	configIface, err := reconciler.readConfiguration(context.Background(), "linux/arm64", userNamespace)
+	g.Expect(configIface).To(BeAssignableToTypeOf(Local{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
 func TestConfigMapParsingForDynamic(t *testing.T) {
 	g := NewGomegaWithT(t)
 	_, reconciler := setupClientAndReconciler(createDynamicHostConfig())


### PR DESCRIPTION
Ideally, all konflux resources must be  appropriately tagged.
IBM doesnt seem to allow to add custom tags to VMs.
Fixes https://issues.redhat.com/browse/KFLUXINFRA-866