### PR TITLE
Set the explicit timeout for TCP address probe

### DIFF
--- a/pkg/ibm/ibmz.go
+++ b/pkg/ibm/ibmz.go
@@ -356,7 +356,7 @@ func checkAddressLive(ctx context.Context, addr string) error {
 	log := logr.FromContextOrDiscard(ctx)
 	log.Info(fmt.Sprintf("checking if address %s is live", addr))
 	server, _ := net.ResolveTCPAddr("tcp", addr+":22")
-	conn, err := net.DialTCP("tcp", nil, server)
+	conn, err := net.DialTimeout(server.Network(), server.String(), 5*time.Second)
 	if err != nil {
 		log.Info("failed to connect to IBM host " + addr)
 		return err


### PR DESCRIPTION
Sometimes it is visible from logs that TCP port probe we're using to check VM is responsible may take up to 2 minutes, blocking the execution thread. This PR sets explicit 5 sec timeout for TCP probe.