### PR TITLE
Fix for missing platform and concurrency fields in UpdateHostPools.

### DIFF
--- a/pkg/reconciler/taskrun/hostupdate_test.go
+++ b/pkg/reconciler/taskrun/hostupdate_test.go
@@ -1,3 +1,20 @@
+// Testing UpdateHostPools - that runs the host update task periodically for static host pools.
+// The spec checks that:
+//	- That one test TaskRun has been created when it should and that none were created when the configuration data is incorrect, that the TaskRun
+//	- That the TaskRun created was a host updating TaskRun was created
+//	- That the configuration data in the TaskRun spec Params and Workspace contain the test data
+//
+// There are 9 test cases:
+// 	1. A positive test to verify all is working correctly
+//	2. A negative test with no configuration data
+//	3. A negative test to verify UpdateHostPools only creates TaskRuns for static hosts
+//	4. A negative test to verify UpdateHostPools only creates TaskRuns when the spec Param key has the correct syntax
+//	5. A negative test to verify data validation on the host address field
+//	6. A negative test to verify data validation on the host concurrency field
+//	7. Another negative test to data verify on the host concurrency field
+//	8. A negative test to verify data validation on the host username field
+//	9. A negative test to verify data validation on the host platform field
+
 package taskrun
 
 import (
@@ -17,6 +34,8 @@ import (
 
 const testNamespace = "default"
 
+// hostDataFromTRSpec creates a map[string]string of configuration data that can be compared
+// to the test case data, from the TaskRun input
 func hostDataFromTRSpec(updateTR v1.TaskRun) map[string]string {
 	newHostData := make(map[string]string)
 
@@ -42,6 +61,8 @@ func hostDataFromTRSpec(updateTR v1.TaskRun) map[string]string {
 	return newHostData
 }
 
+// testConfigDataFromTestData adds a suffix to the test data to create a key format for the TaskRun Spec Params
+// that UpdateHostPools recognizes as having the correct syntax
 func testConfigDataFromTestData(testData map[string]string, configKeySuffix string) map[string]string {
 	testConfigData := make(map[string]string)
 
@@ -53,6 +74,8 @@ func testConfigDataFromTestData(testData map[string]string, configKeySuffix stri
 	return testConfigData
 }
 
+// HostUpdateTaskRunTest - Ginkgo table testing spec for HostUpdateTaskRunTest. Creates a new ConfigMap for each
+// test case and runs them separately
 var _ = Describe("HostUpdateTaskRunTest", func() {
 	var scheme = runtime.NewScheme()
 	var hostConfig = &corev1.ConfigMap{}

--- a/pkg/reconciler/taskrun/updates.go
+++ b/pkg/reconciler/taskrun/updates.go
@@ -24,6 +24,8 @@ func UpdateHostPools(operatorNamespace string, client client.Client, log *logr.L
 	}
 
 	hosts := map[string]*Host{}
+	// A way to transfer the concurrency configuration data from the ConfigMap value (string) to a Param value (also string) not via host.Concurrency
+	// (int) that does not involve strconv.Atoi/Itoi which are expensive.
 	hostsConcurrency := make(map[string]string)
 	for k, v := range cm.Data {
 		if !strings.HasPrefix(k, "host.") {


### PR DESCRIPTION
Also fixed the way the unit test tests the secret field. Un-commented tests for these three fields