### PR TITLE
Remove buzzing log messages

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -64,7 +64,6 @@ func main() {
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 	}
 
-	mainLog.Info("The apis.kcp.dev group is not present - creating standard manager")
 	mgr, err = controller.NewManager(restConfig, mopts)
 	if err != nil {
 		mainLog.Error(err, "unable to start manager")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,7 +42,6 @@ func NewManager(cfg *rest.Config, options ctrl.Options) (ctrl.Manager, error) {
 			controllerLog.Info(fmt.Sprintf("get of taskrun CRD failed with: %s", err.Error()))
 			return false, nil
 		}
-		controllerLog.Info("get of taskrun CRD returned successfully")
 		return true, nil
 	}); err != nil {
 		controllerLog.Error(err, "timed out waiting for taskrun CRD to be created")

--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -42,9 +42,6 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 			hostCount[host] = hostCount[host] + 1
 		}
 	}
-	for k, v := range hostCount {
-		log.Info("host count", "host", k, "count", v)
-	}
 
 	//now select the host with the most free spots
 	//this algorithm is not very complex

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -129,12 +129,9 @@ func (r *ReconcileTaskRun) Reconcile(ctx context.Context, request reconcile.Requ
 		if !errors.IsNotFound(prerr) {
 			log.Error(prerr, "Reconcile key %s as TaskRun unexpected error", request.NamespacedName.String())
 			return ctrl.Result{}, prerr
+		} else {
+			return ctrl.Result{}, nil
 		}
-	}
-	if prerr != nil {
-		msg := "Reconcile key received not found errors for TaskRuns (probably deleted): " + request.NamespacedName.String()
-		log.Info(msg)
-		return ctrl.Result{}, nil
 	}
 	if pr.Annotations != nil {
 		if pr.Annotations[CloudInstanceId] != "" {


### PR DESCRIPTION
Cleanup logs - those messages are taking 80% of logs volume and does not contain any valuable information.