### PR TITLE
SeaLights integration suitable for current test coverage

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Trigger mpc-test-ci workflow
         run: |
           curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.REPO_ACCESS_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -d '{"event_type":"run-tests","client_payload":{"repository":"${{ github.event.pull_request.base.repo.full_name }}","ref":"${{ github.sha }}","head_branch":"${{ github.event.pull_request.head.ref }}"} }' \
             https://api.github.com/repos/${{ github.event.pull_request.base.repo.full_name }}/dispatches

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: konflux-ci/workflow-dispatch@1
+        uses: meyrevived/workflow-dispatch@1
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           workflow: mpc-test-ci.yaml

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -62,7 +62,7 @@ jobs:
               }
             }
             
-            const response = await github.rest.repos.createDispatch({
+            const response = await github.rest.repos.createDispatchEvent({
               owner: '${{ github.event.pull_request.base.repo.owner.login }}',
               repo: '${{ github.event.pull_request.base.repo.name }}',
               event_type: payload.event_type,

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -67,6 +67,9 @@ jobs:
               repo: '${{ github.event.pull_request.base.repo.name }}',
               event_type: payload.event_type,
               client_payload: payload.client_payload,
+              headers: {
+                authorization: `token ${{ secrets.PAT_TOKEN }}`  
+            }
             });
             console.log(response);
   security_scan:

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Write SeaLights token into file
         run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
         with:
-          SEALIGHTS_AGENT_TOKEN: ${{secrets.SEALIGHTS_AGENT_TOKEN}}
+          SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}'
       - name: Fetch branch name for SeaLights commands
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
       - name: Create build name for SeaLights commands

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: multi-platform-controller/workflow-dispatch@1
+        uses: konflux-ci/multi-platform-controller/workflow-dispatch@1
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           workflow: mpc-test-ci.yaml

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -47,19 +47,16 @@ jobs:
           fi
   trigger_unit_test_workflow:
     runs-on: ubuntu-latest
-    steps:
+    steps: 
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}  
-          repository: ${{ github.event.pull_request.head.repo.full_name }}  
-          event-type: trigger-mpc-test-ci-workflow  
-          client-payload: |
-            {
-              "target-branch": "${{ github.event.pull_request.head.ref }}"
-            }
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.REPO_ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{"event_type":"run-tests","client_payload":{"repository":"${{ github.event.pull_request.base.repo.full_name }}","ref":"${{ github.sha }}","head_branch":"${{ github.event.pull_request.head.ref }}"} }' \
+            https://api.github.com/repos/${{ github.event.pull_request.base.repo.full_name }}/dispatches
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -68,7 +68,7 @@ jobs:
           rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz
           ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
       - name: Write SeaLights token into file
-        run: echo "$SEALIGHTS_AGENT_TOKEN" > sltoken.txt
+        run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
         env:
           SEALIGHTS_AGENT_TOKEN: ${{secrets.SEALIGHTS_AGENT_TOKEN}}
       - name: Fetch branch name for SeaLights commands
@@ -77,9 +77,9 @@ jobs:
         run: echo "date=$(date +'%y%m%d.%H:%M')" >> $GITHUB_ENV
       - name: Initiating and configuring SeaLights
         run: |
-          echo "[Sealights] Initiating and configuring SeaLights to scan the branch $BRANCH_NAME and for build $BUILD_NAME"
+          echo "[Sealights] Initiating and configuring SeaLights to scan the pull request branch"
           ./slcli config init --lang go --token ./sltoken.txt
-          ./slcli config create-pr-bsid --app multi-platform-controller --target-branch "main" --pull-request-number $PULL_REQUEST_NAME --latest-commit $LATEST_COMMIT_SHA --repository-url https://github.com/konflux-ci/multi-platform-controller
+          ./slcli config create-pr-bsid --app multi-platform-controller --target-branch "main" --pull-request-number ${PULL_REQUEST_NAME} --latest-commit ${LATEST_COMMIT_SHA} --repository-url https://github.com/konflux-ci/multi-platform-controller
         env:
           PULL_REQUEST_NAME: ${{ github.event.pull_request.number || github.event.issue.number }}
           LATEST_COMMIT_SHA: ${{github.event.pull_request.head.sha}}

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -46,57 +46,20 @@ jobs:
             exit 1
           fi
   unit:
-    name: Golang Unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      - name: Install Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
+      - name: Trigger mpc-test-ci workflow
+        uses: multi-platform-controller/workflow-dispatch@1
         with:
-          go-version-file: "./go.mod"
-      - name: Download SeaLights Go agent and CLI tool
-        run: |
-          echo "[Sealights] Downloading Sealights Golang & CLI Agents..."
-          case $(lscpu | awk '/Architecture:/{print $2}') in
-            x86_64) SL_ARCH="linux-amd64";;
-            arm) SL_ARCH="linux-arm64";;
-          esac
-          wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/latest/slgoagent-$SL_ARCH.tar.gz
-          wget -nv -O sealights-slcli.tar.gz https://agents.sealights.co/slcli/latest/slcli-$SL_ARCH.tar.gz
-          tar -xzf ./sealights-go-agent.tar.gz && tar -xzf ./sealights-slcli.tar.gz
-          rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz
-          ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
-      - name: Write SeaLights token into file
-        run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
-        env:
-          SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}'
-      - name: Fetch branch name for SeaLights commands
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
-      - name: Create build name for SeaLights commands
-        run: echo "date=$(date +'%y%m%d.%H:%M')" >> $GITHUB_ENV
-      - name: Initiating and configuring SeaLights
-        run: |
-          echo "[Sealights] Initiating and configuring SeaLights to scan the pull request branch"
-          ./slcli config init --lang go --token ./sltoken.txt
-          ./slcli config create-pr-bsid --app multi-platform-controller --target-branch "main" --pull-request-number ${PULL_REQUEST_NAME} --latest-commit ${LATEST_COMMIT_SHA} --repository-url https://github.com/konflux-ci/multi-platform-controller
-        env:
-          PULL_REQUEST_NAME: ${{ github.event.pull_request.number || github.event.issue.number }}
-          LATEST_COMMIT_SHA: ${{github.event.pull_request.head.sha}}
-      - name: Run the SeaLights scan
-        run: |
-          echo "[Sealights] Running the SeaLights scan"
-          ./slcli scan --bsid buildSessionId.txt  --path-to-scanner ./slgoagent --workspacepath ./ --scm git --scmBaseUrl https://github.com/konflux-ci/multi-platform-controller --scmVersion “0” --scmProvider github
-      - name: Build
-        run: make build
-      - name: Test
-        run: make test
-      - name: Codecov
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4
-      - name: clean all SeaLights secret stuff
-        run: |
-          echo "[Sealights] Cleaning up after SeaLights run"
-          rm sltoken.txt buildSessionId.txt
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          workflow: mpc-test-ci.yaml
+          ref: ${{github.sha}}
+          inputs: |
+            target-branch: ${{github.event.pull_request.head.ref}}
+        env: 
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -45,21 +45,30 @@ jobs:
             git --no-pager diff
             exit 1
           fi
-  unit:
+  trigger_unit_test_workflow:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: meyrevived/multi-platform-controller/workflow-dispatch@v1
+        uses: actions/github-script@v7.0.1 #v7
         with:
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          workflow: mpc-test-ci.yaml
-          ref: ${{github.sha}}
-          inputs: |
-            target-branch: ${{github.event.pull_request.head.ref}}
-        env: 
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          script: |
+            const payload = {
+              event_type: 'pull_request_target',  // Emulate pull_request_target
+              client_payload: {
+                ref: '${{ github.sha }}',
+                target_branch: '${{ github.event.pull_request.head.ref }}'
+              }
+            }
+            
+            const response = await github.rest.repos.createDispatch({
+              owner: '${{ github.event.pull_request.base.repo.owner.login }}',
+              repo: '${{ github.event.pull_request.base.repo.name }}',
+              event_type: payload.event_type,
+              client_payload: payload.client_payload,
+            });
+            console.log(response);
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: meyrevived/multi-platform-controller/workflow-dispatch@1
+        uses: meyrevived/multi-platform-controller/workflow-dispatch
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           workflow: mpc-test-ci.yaml

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,27 +51,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: actions/github-script@v5 
+        uses: peter-evans/repository-dispatch@v3
         with:
-          script: |
-            const payload = {
-              event_type: 'pull_request_target',  // Emulate pull_request_target
-              client_payload: {
-                ref: '${{ github.sha }}',
-                target_branch: '${{ github.event.pull_request.head.ref }}'
-              }
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}  
+          repository: ${{ github.event.pull_request.head.repo.full_name }}  
+          event-type: trigger-mpc-test-ci-workflow  
+          client-payload: |
+            {
+              "target-branch": "${{ github.event.pull_request.head.ref }}"
             }
-            
-            const response = await github.rest.repos.createDispatchEvent({
-              owner: '${{ github.event.pull_request.base.repo.owner.login }}',
-              repo: '${{ github.event.pull_request.base.repo.name }}',
-              event_type: payload.event_type,
-              client_payload: payload.client_payload,
-              headers: {
-                authorization: `token ${{ secrets.PAT_TOKEN }}`  
-            }
-            });
-            console.log(response);
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -93,6 +93,10 @@ jobs:
         run: make test
       - name: Codecov
         uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4
+      - name: clean all SeaLights secret stuff
+        run: |
+          echo "[Sealights] Cleaning up after SeaLights run"
+          rm sltoken.txt buildSessionId.txt
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: meyrevived/workflow-dispatch@1
+        uses: meyrevived/multi-platform-controller/workflow-dispatch@1
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           workflow: mpc-test-ci.yaml

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -1,7 +1,7 @@
 name: Validate PR - golang CI
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   lint:
     name: Lint
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4
         with:
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
       - name: Check go mod status
         run: |
           go mod tidy
@@ -54,7 +54,39 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
+      - name: Download SeaLights Go agent and CLI tool
+        run: |
+          echo "[Sealights] Downloading Sealights Golang & CLI Agents..."
+          case $(lscpu | awk '/Architecture:/{print $2}') in
+            x86_64) SL_ARCH="linux-amd64";;
+            arm) SL_ARCH="linux-arm64";;
+          esac
+          wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/latest/slgoagent-$SL_ARCH.tar.gz
+          wget -nv -O sealights-slcli.tar.gz https://agents.sealights.co/slcli/latest/slcli-$SL_ARCH.tar.gz
+          tar -xzf ./sealights-go-agent.tar.gz && tar -xzf ./sealights-slcli.tar.gz
+          rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz
+          ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
+      - name: Write SeaLights token into file
+        run: echo "$SEALIGHTS_AGENT_TOKEN" > sltoken.txt
+        env:
+          SEALIGHTS_AGENT_TOKEN: ${{secrets.SEALIGHTS_AGENT_TOKEN}}
+      - name: Fetch branch name for SeaLights commands
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+      - name: Create build name for SeaLights commands
+        run: echo "date=$(date +'%y%m%d.%H:%M')" >> $GITHUB_ENV
+      - name: Initiating and configuring SeaLights
+        run: |
+          echo "[Sealights] Initiating and configuring SeaLights to scan the branch $BRANCH_NAME and for build $BUILD_NAME"
+          ./slcli config init --lang go --token ./sltoken.txt
+          ./slcli config create-pr-bsid --app multi-platform-controller --target-branch "main" --pull-request-number $PULL_REQUEST_NAME --latest-commit $LATEST_COMMIT_SHA --repository-url https://github.com/konflux-ci/multi-platform-controller
+        env:
+          PULL_REQUEST_NAME: ${{ github.event.pull_request.number || github.event.issue.number }}
+          LATEST_COMMIT_SHA: ${{github.event.pull_request.head.sha}}
+      - name: Run the SeaLights scan
+        run: |
+          echo "[Sealights] Running the SeaLights scan"
+          ./slcli scan --bsid buildSessionId.txt  --path-to-scanner ./slgoagent --workspacepath ./ --scm git --scmBaseUrl https://github.com/konflux-ci/multi-platform-controller --scmVersion “0” --scmProvider github
       - name: Build
         run: make build
       - name: Test
@@ -69,13 +101,13 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
       # https://github.com/securego/gosec/blob/12be14859bc7d4b956b71bef0b443694aa519d8a/README.md#integrating-with-code-scanning
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
-          args: '-tags normal,periodic -no-fail -fmt sarif -out results.sarif ./...'
+          args: "-tags normal,periodic -no-fail -fmt sarif -out results.sarif ./..."
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3
         with:

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -69,7 +69,7 @@ jobs:
           ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
       - name: Write SeaLights token into file
         run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
-        env:
+        with:
           SEALIGHTS_AGENT_TOKEN: ${{secrets.SEALIGHTS_AGENT_TOKEN}}
       - name: Fetch branch name for SeaLights commands
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -69,7 +69,7 @@ jobs:
           ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
       - name: Write SeaLights token into file
         run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
-        with:
+        env:
           SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}'
       - name: Fetch branch name for SeaLights commands
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: actions/github-script@v7.0.1 #v7
+        uses: actions/github-script@4020e461acd7a80762cdfff123a1fde368246fa4 #v7
         with:
           script: |
             const payload = {

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: meyrevived/multi-platform-controller/workflow-dispatch
+        uses: meyrevived/multi-platform-controller/workflow-dispatch@v1
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           workflow: mpc-test-ci.yaml

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: konflux-ci/multi-platform-controller/workflow-dispatch@1
+        uses: konflux-ci/workflow-dispatch@1
         with:
           repository: ${{github.event.pull_request.head.repo.full_name}}
           workflow: mpc-test-ci.yaml

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: actions/github-script@4020e461acd7a80762cdfff123a1fde368246fa4 #v7
+        uses: actions/github-script@v5 
         with:
           script: |
             const payload = {

--- a/.github/workflows/mpc-test-ci.yaml
+++ b/.github/workflows/mpc-test-ci.yaml
@@ -1,0 +1,62 @@
+name: Validate PR - Testing Phase - golang CI
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches: [main]
+jobs:
+  checkout_and_test:
+    name: Golang Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Install Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
+        with:
+          go-version-file: "./go.mod"
+      - name: Download SeaLights Go agent and CLI tool
+        run: |
+          echo "[Sealights] Downloading Sealights Golang & CLI Agents..."
+          case $(lscpu | awk '/Architecture:/{print $2}') in
+            x86_64) SL_ARCH="linux-amd64";;
+            arm) SL_ARCH="linux-arm64";;
+          esac
+          wget -nv -O sealights-go-agent.tar.gz https://agents.sealights.co/slgoagent/latest/slgoagent-$SL_ARCH.tar.gz
+          wget -nv -O sealights-slcli.tar.gz https://agents.sealights.co/slcli/latest/slcli-$SL_ARCH.tar.gz
+          tar -xzf ./sealights-go-agent.tar.gz && tar -xzf ./sealights-slcli.tar.gz
+          rm -f ./sealights-go-agent.tar.gz ./sealights-slcli.tar.gz
+          ./slgoagent -v 2> /dev/null | grep version && ./slcli -v 2> /dev/null | grep version
+      - name: Write SeaLights token into file
+        run: echo "${SEALIGHTS_AGENT_TOKEN}" > sltoken.txt
+        env:
+          SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}'
+      - name: Fetch branch name for SeaLights commands
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
+      - name: Create build name for SeaLights commands
+        run: echo "date=$(date +'%y%m%d.%H:%M')" >> $GITHUB_ENV
+      - name: Initiating and configuring SeaLights
+        run: |
+          echo "[Sealights] Initiating and configuring SeaLights to scan the pull request branch"
+          ./slcli config init --lang go --token ./sltoken.txt
+          ./slcli config create-pr-bsid --app multi-platform-controller --target-branch "main" --pull-request-number ${PULL_REQUEST_NAME} --latest-commit ${LATEST_COMMIT_SHA} --repository-url https://github.com/konflux-ci/multi-platform-controller
+        env:
+          PULL_REQUEST_NAME: ${{ github.event.pull_request.number || github.event.issue.number }}
+          LATEST_COMMIT_SHA: ${{github.event.pull_request.head.sha}}
+      - name: Run the SeaLights scan
+        run: |
+          echo "[Sealights] Running the SeaLights scan"
+          ./slcli scan --bsid buildSessionId.txt  --path-to-scanner ./slgoagent --workspacepath ./ --scm git --scmBaseUrl https://github.com/konflux-ci/multi-platform-controller --scmVersion “0” --scmProvider github
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test
+      - name: Codecov
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4
+      - name: clean all SeaLights secret stuff
+        run: |
+          echo "[Sealights] Cleaning up after SeaLights run"
+          rm sltoken.txt buildSessionId.txt

--- a/.github/workflows/mpc-test-ci.yaml
+++ b/.github/workflows/mpc-test-ci.yaml
@@ -1,8 +1,10 @@
 name: Validate PR - Testing Phase - golang CI
 
 on:
-  repository_dispatch:
-    types: [trigger-mpc-test-ci-workflow]
+  workflow_run:
+    workflows: ["go-ci.yaml"]
+    types:
+      - completed
 jobs:
   checkout_and_test:
     name: Golang Unit tests
@@ -11,8 +13,8 @@ jobs:
       - name: Check out code of the forked repository's head branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
-          repository: ${{ github.event.client_payload.target_branch }}  
-          ref: ${{ github.event.client_payload.target_branch }}  
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}  
+          ref: ${{ github.event.pull_request.head.ref }}  
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:

--- a/.github/workflows/mpc-test-ci.yaml
+++ b/.github/workflows/mpc-test-ci.yaml
@@ -2,7 +2,7 @@ name: Validate PR - Testing Phase - golang CI
 
 on:
   repository_dispatch:
-    types: [pull_request_target]
+    types: [trigger-mpc-test-ci-workflow]
 jobs:
   checkout_and_test:
     name: Golang Unit tests
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           repository: ${{ github.event.client_payload.target_branch }}  
-          ref: ${{ github.event.client_payload.ref }}  
+          ref: ${{ github.event.client_payload.target_branch }}  
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:

--- a/.github/workflows/mpc-test-ci.yaml
+++ b/.github/workflows/mpc-test-ci.yaml
@@ -1,19 +1,18 @@
 name: Validate PR - Testing Phase - golang CI
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-    branches: [main]
+  repository_dispatch:
+    types: [pull_request_target]
 jobs:
   checkout_and_test:
     name: Golang Unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: Check out code of the forked repository's head branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          repository: ${{ github.event.client_payload.target_branch }}  
+          ref: ${{ github.event.client_payload.ref }}  
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:


### PR DESCRIPTION
Adding a few steps with SeaLights agent download and setup to  go-ci.yaml github action. SeaLights is added before the `make test `step, and then later a cleanup step to get rid of everything SeaLights-related. 
For KFLUXINFRA-1143 and KFLUXINFRA-1064 in general.