### PR TITLE
Tweak event and log language

### DIFF
--- a/pkg/reconciler/taskrun/dynamic.go
+++ b/pkg/reconciler/taskrun/dynamic.go
@@ -114,7 +114,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 			if err != nil {
 				return reconcile.Result{}, err
 			}
-			message := fmt.Sprintf("launching %s provisioning task for %s", r.instanceTag, tr.Name)
+			message := fmt.Sprintf("starting %s provisioning task for %s", r.instanceTag, tr.Name)
 			log.Info(message)
 			r.eventRecorder.Event(tr, "Normal", "Provisioning", message)
 			err = launchProvisioningTask(taskRun, ctx, tr, secretName, r.sshSecret, address, r.CloudProvider.SshUser(), r.platform, r.sudoCommands)


### PR DESCRIPTION
This is just a little confusing. There are two parts, launching the VM and provisioning the VM. Here, the provisioning logline said that it was "launching" the provisioning task which, while correct, made it a little confusing when reading through multiple log lines and multiple events.

Just change the word to make it clear that it's a separate phase, not more "launching".