### PR TITLE
Add local development scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target
 .project
 .classpath
 .vscode/
+.tmp
 *~
 local-test
 out

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ dev-image: build build-otp
 dev: dev-image
 	./deploy/development.sh
 
-dev-minikube: dev
+.PHONY: dev-minikube
+dev-minikube: dev-image
+	./deploy/generate_ca.sh
 	./deploy/minikube-development.sh
 
 ## Tool Versions

--- a/deploy/generate_ca.sh
+++ b/deploy/generate_ca.sh
@@ -19,5 +19,8 @@ openssl req -x509 -new -nodes -key ${GENCERTS_DIR}/ca.key -subj "/CN=otp-service
 # verify created
 cat ${GENCERTS_DIR}/ca.crt >/dev/null
 if [ $? -eq 0 ]; then
-  echo "CA bundle created"
+    echo "CA bundle created"
+  else
+    echo "CA generation failed"
+    exit 1
 fi

--- a/deploy/generate_ca.sh
+++ b/deploy/generate_ca.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+#  This script generates the certificates needed for the otp
+
+set -e
+
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+TEMP_DIR="${THIS_DIR}/../.tmp"
+
+GENCERTS_DIR="${GENCERTS_DIR:-"${TEMP_DIR}/k8s/certs"}"
+
+echo "Generating CA bundle"
+mkdir -p "${GENCERTS_DIR}"
+
+openssl genrsa -out ${GENCERTS_DIR}/ca.key 2048
+openssl req -x509 -new -nodes -key ${GENCERTS_DIR}/ca.key -subj "/CN=otp-service.mpc.svc" -days 365 -out ${GENCERTS_DIR}/ca.crt
+
+# verify created
+cat ${GENCERTS_DIR}/ca.crt >/dev/null
+if [ $? -eq 0 ]; then
+  echo "CA bundle created"
+fi

--- a/deploy/minikube-development.sh
+++ b/deploy/minikube-development.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+DIR=`dirname $0`
+TEMP_DIR="${DIR}/../.tmp"
+
+if [ -z "$QUAY_USERNAME" ]; then
+    echo "Set QUAY_USERNAME"
+    exit 1
+fi
+
+
+kubectl create ns multi-platform-controller --dry-run=client -o yaml | kubectl apply -f -
+kubectl config set-context --current --namespace=multi-platform-controller
+
+kubectl delete --ignore-not-found secret awskeys awsiam ibmiam
+kubectl create secret generic awskeys --from-file=id_rsa=$ID_RSA_KEY
+kubectl create secret generic awsiam --from-literal=access-key-id=$MULTI_ARCH_ACCESS_KEY --from-literal=secret-access-key=$MULTI_ARCH_SECRET_KEY
+kubectl create secret generic ibmiam --from-literal=api-key=$IBM_CLOUD_API_KEY
+kubectl label secrets awsiam build.appstudio.redhat.com/multi-platform-secret=true
+kubectl label secrets ibmiam build.appstudio.redhat.com/multi-platform-secret=true
+kubectl label secrets awskeys build.appstudio.redhat.com/multi-platform-secret=true
+
+# Check Tekton
+kubectl describe crd pipelinerun >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "Tekton API already installed"
+else
+  echo "Tekton API not found, installing"
+  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+  # If you need full Tekton operator, comment the line above and uncomment below:
+  # kubectl apply --filename https://storage.googleapis.com/tekton-releases/operator/latest/release.yaml
+fi
+
+echo "Installing the Operator"
+rm -r $DIR/overlays/development
+find $DIR -name dev-template -exec cp -r {} {}/../development \;
+find $DIR -path \*development\*.yaml -exec sed -i s/QUAY_USERNAME/${QUAY_USERNAME}/ {} \;
+kubectl apply -k $DIR/overlays/development
+
+kubectl rollout restart deployment -n multi-platform-controller multi-platform-controller
+
+echo "Creating OTP TLS secret"
+kubectl create secret tls otp-tls-secrets --key ${TEMP_DIR}/k8s/certs/ca.key --cert ${TEMP_DIR}/k8s/certs/ca.crt --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout restart deployment -n multi-platform-controller multi-platform-otp-server


### PR DESCRIPTION
This PR allows to deploy MPC to any kind of locally running kubernetes, i.e. minikube or k3s or whatever.
It is _not_ yet tested with AWS and IBM cloud credentials, that will be done separately.