### PR TITLE
KFLUXINFRA-1143: SeaLights scan on merged main implementation via github workflows

### DIFF
--- a/.github/workflows/sealights-mpc-scan-on-merged-main.yaml
+++ b/.github/workflows/sealights-mpc-scan-on-merged-main.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-after-merge:
-    if: github.event.repository.default_branch == 'main'
+    if: github.event.repository == 'konflux-ci/multi-platform-controller'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Main Repository

--- a/.github/workflows/trigger-sealights-mpc-scan-on-merged-main.yaml
+++ b/.github/workflows/trigger-sealights-mpc-scan-on-merged-main.yaml
@@ -1,0 +1,14 @@
+name: Trigger on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  pr-merge:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Merge Complete
+        run: echo "Pull request merged into main. Triggering SeaLights scan on merged main workflow."


### PR DESCRIPTION
This pull request adds the (hopefully) final workflow that runs on a closed pull request and is an event the workflow_run workflow from pull request #360 that actually runs SeaLights scan on the new main branch, listens to.
Also in this PR is a small change to the if statement in the workflow_run file that is a more percise check to verify it's definitely not running on the forked branch context.