### PR TITLE
KFLUXINFRA-1143: fix for wrong if condition in workflow_run 

### DIFF
--- a/.github/workflows/sealights-mpc-scan-on-merged-main.yaml
+++ b/.github/workflows/sealights-mpc-scan-on-merged-main.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-after-merge:
-    if: github.event.repository.default_branch == 'main'
+    if: github.event.repository == 'konflux-ci/multi-platform-controller'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Main Repository

--- a/.github/workflows/sealights-mpc-scan-on-merged-main.yaml
+++ b/.github/workflows/sealights-mpc-scan-on-merged-main.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-after-merge:
-    if: github.event.repository == 'konflux-ci/multi-platform-controller'
+    if: github.repository == 'konflux-ci/multi-platform-controller'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Main Repository

--- a/.github/workflows/trigger-sealights-mpc-scan-on-merged-main.yaml
+++ b/.github/workflows/trigger-sealights-mpc-scan-on-merged-main.yaml
@@ -1,0 +1,14 @@
+name: Trigger on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  pr-merge:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Merge Complete
+        run: echo "Pull request merged into main. Triggering SeaLights scan on merged main workflow."


### PR DESCRIPTION
The workflow_run was getting skipped because I coded it to check the triggering event's repo, not the repo all of these actions were being run on. Because this workflow is triggered by a pull request, the event repo is never the main repo, which is not what I needed. Thus, the workflow was being skipped all the time.