### PR TITLE
KFLUXINFRA-1064  adding checks for failed pull request workflow runs

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -4,7 +4,7 @@ on:
     branches: [ main ]
 permissions:
   checks: read
-  contents: write
+  contents: read
   actions: write
 jobs:
   lint:
@@ -55,7 +55,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Trigger mpc-test-ci workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}  
           repository: ${{ github.event.pull_request.head.repo.full_name }}  
@@ -67,14 +67,25 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const checkRuns = github.rest.checks.listForRef({
+            try {
+              const checkRuns = github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
             });
+
+            if (!response.data || !response.data.check_runs) {
+              core.setFailed('No check runs found for the specified ref.');
+              return;
+            }
+            console.log(response);
+
             const targetWorkflow = checkRuns.data.check_runs.find(run => run.name === 'Validate PR - Testing Phase With SeaLights Monitoring - golang CI');
             if (!targetWorkflow || targetWorkflow.conclusion !== 'success') {
               core.setFailed('Pull Request Target Workflow did not pass.');
+            }
+              } catch (error) {
+            console.error('API call failed:', error);
             }
   security_scan:
     name: Security scan

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -61,6 +61,21 @@ jobs:
           event-type: trigger-mpc-test-with-sealights-ci
           client-payload: '{"target-branch": "${{ github.event.pull_request.head.ref }}"}'
         continue-on-error: true
+      - name: Wait for Target Workflow
+        id: wait
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const runId = context.run_id;
+            const checkRuns = await github.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+            });
+            const targetWorkflow = checkRuns.data.check_runs.find(run => run.name === 'Validate PR - Testing Phase With SeaLights Monitoring - golang CI');
+            if (!targetWorkflow || targetWorkflow.conclusion !== 'success') {
+              core.setFailed('Pull Request Target Workflow did not pass.');
+            }
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -66,9 +66,10 @@ jobs:
         id: wait
         uses: actions/github-script@v6
         with:
+          debug: true
           script: |
             try {
-              const checkRuns = github.rest.checks.listForRef({
+              const response = github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,
@@ -80,7 +81,7 @@ jobs:
             }
             console.log(response);
 
-            const targetWorkflow = checkRuns.data.check_runs.find(run => run.name === 'Validate PR - Testing Phase With SeaLights Monitoring - golang CI');
+            const targetWorkflow = response.data.check_runs.find(run => run.name === 'Validate PR - Testing Phase With SeaLights Monitoring - golang CI');
             if (!targetWorkflow || targetWorkflow.conclusion !== 'success') {
               core.setFailed('Pull Request Target Workflow did not pass.');
             }

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches: [ main ]
 permissions:
+  checks: read
   contents: write
   actions: write
 jobs:
@@ -66,8 +67,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const runId = context.run_id;
-            const checkRuns = await github.checks.listForRef({
+            const checkRuns = github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.sha,

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -62,32 +62,6 @@ jobs:
           event-type: trigger-mpc-test-with-sealights-ci
           client-payload: '{"target-branch": "${{ github.event.pull_request.head.ref }}"}'
         continue-on-error: true
-      - name: Wait for Target Workflow
-        id: wait
-        uses: actions/github-script@v6
-        with:
-          debug: true
-          script: |
-            try {
-              const response = github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: github.event.pull_request.head.sha,
-            });
-
-            if (!response.data || !response.data.check_runs) {
-              core.setFailed('No check runs found for the specified ref.');
-              return;
-            }
-            console.log(response);
-
-            const targetWorkflow = response.data.check_runs.find(run => run.name === 'Validate PR - Testing Phase With SeaLights Monitoring - golang CI');
-            if (!targetWorkflow || targetWorkflow.conclusion !== 'success') {
-              core.setFailed('Pull Request Target Workflow did not pass.');
-            }
-              } catch (error) {
-            console.error('API call failed:', error);
-            }
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -72,7 +72,7 @@ jobs:
               const response = github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.sha,
+              ref: github.event.pull_request.head.sha,
             });
 
             if (!response.data || !response.data.check_runs) {

--- a/.github/workflows/sealights-mpc-test-ci.yaml
+++ b/.github/workflows/sealights-mpc-test-ci.yaml
@@ -12,11 +12,20 @@ on:
   repository_dispatch:
     types: [trigger-mpc-test-with-sealights-ci]
 
+concurrency:
+  group: ${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   checkout_and_test:
     name: Golang Unit tests
     runs-on: ubuntu-latest
     steps:
+      - name: Handle invalid context
+        if: ${{ !github.event.pull_request.head.sha || !github.event.pull_request.number }}
+        run: |
+          echo "Invalid context for this workflow run. Exiting."
+          exit 1
       - name: Check out code of the forked repository's head branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -43,9 +52,12 @@ jobs:
         env:
           SEALIGHTS_AGENT_TOKEN: '${{secrets.SEALIGHTS_AGENT_TOKEN}}'
       - name: Initiating and configuring SeaLights
+        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha && github.event.pull_request.number }}
         run: |
           echo "[Sealights] Initiating and configuring SeaLights to scan the pull request branch"
           ./slcli config init --lang go --token ./sltoken.txt
+          echo "Latest commit sha: ${LATEST_COMMIT_SHA}"
+          echo "PR Number: ${PULL_REQUEST_NUMBER}"
           ./slcli config create-pr-bsid --app multi-platform-controller --target-branch "main" --pull-request-number ${PULL_REQUEST_NUMBER} --latest-commit ${LATEST_COMMIT_SHA} --repository-url https://github.com/konflux-ci/multi-platform-controller
         env:
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}


### PR DESCRIPTION
I've noticed that the [pull_request_target workflow](https://github.com/konflux-ci/multi-platform-controller/actions/workflows/sealights-mpc-test-ci.yaml) has been triggered by no apparent action and that the step for configuring the SeaLights agent there is failing because there's missing data from the workflow run.
To debug when this is happening, debug that this is definitely something in our system and not something SeaLights can't find and to prevent this workflow from running in parallel (thus leading to missing context information needed for the SeaLights agent) I've added some additional steps to this workflow.

Additionally, there are additions to go-ci.yaml to ensure the pull_request_target workflow that's running the unit tests is monitored for failure so that if it does fail, go-ci fails as well. This is because I did not see the [failed runs](https://github.com/konflux-ci/multi-platform-controller/actions/workflows/sealights-mpc-test-ci.yaml) being listed anywhere as failed checks for [the PR](https://github.com/konflux-ci/multi-platform-controller/pull/361) they were happening in parallel to. 