### PR TITLE
Fix for invalid group value on concurrency field when running workflow on push event

### DIFF
--- a/.github/workflows/mpc-test-sealights.yaml
+++ b/.github/workflows/mpc-test-sealights.yaml
@@ -15,7 +15,7 @@ on:
     types: [trigger-mpc-test-with-sealights-ci]
 
 concurrency:
-  group: ${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request_target' && github.event.pull_request.number) || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Running the united workflow from  the [one-workflow-to-rule-them-all](https://github.com/konflux-ci/multi-platform-controller/commit/13574e4c1f9f3aceffdf18959ef3ffbddc9fba8d) commit in a push event context causes it to fail on startup with the error message
```
Invalid workflow file: .github/workflows/mpc-test-sealights.yaml#L18
The workflow is not valid. .github/workflows/mpc-test-sealights.yaml (Line: 18, Col: 10): Unexpected value ''
```
See example [here](https://github.com/konflux-ci/multi-platform-controller/actions/runs/12558932143)
This is because of the concurrency group parameter that is less dynamic. 
This commit will fix it, creating a group value that is more specific to the event type and matches both event types.