### PR TITLE
Bug fix in checking the environment variable for workflow type

### DIFF
--- a/.github/workflows/mpc-test-sealights.yaml
+++ b/.github/workflows/mpc-test-sealights.yaml
@@ -38,13 +38,13 @@ jobs:
           echo "Invalid context for this workflow run. Exiting."
           exit 1
       - name: Check out pull request head code - on pull_request event
-        if: ${{env.on-event}} == "pull_request"
+        if: ${{env.on-event == "pull_request"}}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}  
           ref: ${{ github.event.pull_request.head.ref }}  
       - name: Check out main code - on push event
-        if: ${{env.on-event}} == "push"
+        if: ${{env.on-event == "push"}}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
@@ -71,7 +71,7 @@ jobs:
           echo "[Sealights] Initiating the SeaLights agent to Goland and handing it the token"
           ./slcli config init --lang go --token ./sltoken.txt
       - name: Configuring SeaLights - on pull_request event
-        if: ${{env.on-event}} == "pull_request"
+        if: ${{env.on-event == "pull_request"}}
         run: |
           echo "[Sealights] Configuring SeaLights to scan the pull request branch"
           echo "Latest commit sha: ${LATEST_COMMIT_SHA}"
@@ -81,7 +81,7 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           LATEST_COMMIT_SHA: ${{github.event.pull_request.head.sha}}
       - name: Configuring SeaLights - on push event
-        if: ${{env.on-event}} == "push"
+        if: ${{env.on-event == "push"}}
         run: |
           echo "[Sealights] Configuring SeaLights to scan the main branch after pull request was closed"
           ./slcli config create-bsid --app multi-platform-controller --branch main --build multi-platform-controller-main-$(date +'%Y.%m.%d_%H:%M')


### PR DESCRIPTION
**Previously on The SeaLights-MPC Saga:**
SeaLights asked that we'll add a testing phase to the github workflow that runs a SeaLights code scan on the main branch after it's been merged with new code.

This basically made sealights-mpc-test-ci.yaml extremely similar to this workflow and so I added code that runs this scan-and-test procedure to on->push events. Steps that need to run differently on pull requests and on push are checked to see how to run them.
Thus the name change to sealights-mpc-test-ci.yaml, removing sealights-mpc-test-on-merged-main.yaml and trigger-sealights-mpc-test-on-merged-main.yaml. codecov-main.yaml is also removed because mpc-test-sealights.yaml is already running codecov action. This was done in https://github.com/konflux-ci/multi-platform-controller/pull/372

**Today's episode:**
The way the if checks on push/pull_request steps is not written correctly and so are not truly evaluated for their value. This makes both the push steps and the pull_requesy steps run. On pull request everything supposedly works well (other than the fact that tests are run on the base branch not the head branch) but on push events, the SeaLights command for setting up a BuildSessionID requires information from a pull request event, so without those the command fails and the whole workflow fails.
