### PR TITLE
A simpler fix to the event type environment variable faulty check

### DIFF
--- a/.github/workflows/mpc-test-sealights.yaml
+++ b/.github/workflows/mpc-test-sealights.yaml
@@ -24,27 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Determine workflow run event context
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "Running tests on the merged main branch"
-            echo "on-event=push" >> $GITHUB_ENV 
-          else
-            echo "Running tests on the pull request head branch"
-            echo "on-event=pull_request" >> $GITHUB_ENV
-          fi
+        run: echo "on-event=${{ github.event_name }}" >> $GITHUB_ENV
       - name: Handle invalid context for pull requests
-        if: ${{ env.on-event == 'pull_request' && (!github.event.pull_request.head.sha || !github.event.pull_request.number) }}
+        if: ${{ env.on-event == 'pull_request_target' && (!github.event.pull_request.head.sha || !github.event.pull_request.number) }}
         run: |
           echo "Invalid context for this workflow run. Exiting."
           exit 1
       - name: Check out pull request head code - on pull_request event
-        if: ${{env.on-event == "pull_request"}}
+        if: env.on-event == 'pull_request_target'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}  
           ref: ${{ github.event.pull_request.head.ref }}  
       - name: Check out main code - on push event
-        if: ${{env.on-event == "push"}}
+        if: env.on-event == 'push'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
@@ -71,7 +64,7 @@ jobs:
           echo "[Sealights] Initiating the SeaLights agent to Goland and handing it the token"
           ./slcli config init --lang go --token ./sltoken.txt
       - name: Configuring SeaLights - on pull_request event
-        if: ${{env.on-event == "pull_request"}}
+        if: env.on-event == 'pull_request_target'
         run: |
           echo "[Sealights] Configuring SeaLights to scan the pull request branch"
           echo "Latest commit sha: ${LATEST_COMMIT_SHA}"
@@ -81,7 +74,7 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           LATEST_COMMIT_SHA: ${{github.event.pull_request.head.sha}}
       - name: Configuring SeaLights - on push event
-        if: ${{env.on-event == "push"}}
+        if: env.on-event == 'push'
         run: |
           echo "[Sealights] Configuring SeaLights to scan the main branch after pull request was closed"
           ./slcli config create-bsid --app multi-platform-controller --branch main --build multi-platform-controller-main-$(date +'%Y.%m.%d_%H:%M')


### PR DESCRIPTION
**Previously on The SeaLights-MPC Saga:**
SeaLights asked that we'll add a testing phase to the github workflow that runs a SeaLights code scan on the main branch after it's been merged with new code.

This basically made sealights-mpc-test-ci.yaml extremely similar to this workflow and so I added code that runs this scan-and-test procedure to on->push events. Steps that need to run differently on pull requests and on push are checked to see how to run them.
Thus the name change to sealights-mpc-test-ci.yaml, removing sealights-mpc-test-on-merged-main.yaml and trigger-sealights-mpc-test-on-merged-main.yaml. codecov-main.yaml is also removed because mpc-test-sealights.yaml is already running codecov action. This was done in https://github.com/konflux-ci/multi-platform-controller/pull/372

**Today's episode:**
The way the if checks on push/pull_request steps is not written correctly invalidate the workflow, causing it to fail no matter what runs. This is a fix I tested in [a small test repo](https://github.com/meyrevived/Test_workflows/actions/workflows/main.yml)