### PR TITLE
Revert "Update runner images to the recent version"

### DIFF
--- a/deploy/operator/provision-shared-host.yaml
+++ b/deploy/operator/provision-shared-host.yaml
@@ -37,7 +37,7 @@ spec:
         value: $(params.SUDO_COMMANDS)
   steps:
     - name: provision
-      image: quay.io/redhat-appstudio/multi-platform-runner:0e55eb996181ec207bf60badc7d3331d6a11c113@sha256:fe5f34be30b0945967fc2b3a4f3da675e475c77e6333c5e56c444ca10b09a2e5
+      image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /tls

--- a/deploy/operator/update-host.yaml
+++ b/deploy/operator/update-host.yaml
@@ -15,7 +15,7 @@ spec:
     - name: ssh
   steps:
     - name: update
-      image: quay.io/redhat-appstudio/multi-platform-runner:0e55eb996181ec207bf60badc7d3331d6a11c113@sha256:fe5f34be30b0945967fc2b3a4f3da675e475c77e6333c5e56c444ca10b09a2e5
+      image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
       imagePullPolicy: IfNotPresent
       script: |
         #!/bin/bash


### PR DESCRIPTION
Reverts konflux-ci/multi-platform-controller#388 as we're started to get:

```
2025/01/15 15:22:53 warning: unsuccessful cred copy: ".docker" from "/tekton/creds" to "/root": unable to create destination directory: mkdir /root/.docker: permission denied
set -eu
set -o pipefail
mkdir -p /root/.ssh
mkdir: cannot create directory '/root/.ssh': Permission denied
```