### PR TITLE
Adding a unit test for IBMPowerProvider 

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -25,8 +25,7 @@ var _ = Describe("Ec2 Connection Test", func() {
 				}
 
 			},
-			Entry("Positive test - IP address", "3.87.91.87", false),
-			Entry("Positive test - DNS name", "ec2-3-87-91-87.compute-1.amazonaws.com", false),
+			Entry("Positive test - IP address", "150.239.19.36", false),
 			Entry("Negative test - no such IP address", "192.168.4.231", true),
 			Entry("Negative test - no such DNS name", "not a DNS name, that's for sure", true),
 			Entry("Negative test - not an IP address", "Not an IP address", true),

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -14,7 +14,6 @@ var _ = Describe("Ec2 Connection Test", func() {
 	Describe("Testing pingSSHIp", func() {
 		DescribeTable("Testing the ability to ping via SSH a remote AWS ec2 instance",
 			func(testInstanceIP string, shouldFail bool) {
-				Skip("Skipping test because VM setup is missing so its too fragile")
 
 				ec2IPAddress, err := pingSSHIp(context.TODO(), testInstanceIP)
 

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// This test is only here to check SeaLights integration, it will be replaced with a more robust integration
-// test for the AWS API
+// This test is only here to check AWS connectivity in a very primitive and quick way until KFLUXINFRA-1065
+// work starts
 var _ = Describe("Ec2 Connection Test", func() {
 
 	Describe("Testing pingSSHIp", func() {

--- a/pkg/ibm/ibm_suite_test.go
+++ b/pkg/ibm/ibm_suite_test.go
@@ -1,0 +1,13 @@
+package ibm
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIbm(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ibm Suite")
+}

--- a/pkg/ibm/ibmp_test.go
+++ b/pkg/ibm/ibmp_test.go
@@ -1,0 +1,71 @@
+package ibm
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var config = IBMPowerDynamicConfig{
+	SystemNamespace: "test-namespace",
+	Secret:          "test-secret",
+	Key:             "test-key",
+	Image:           "test-image",
+	Url:             "test-url",
+	CRN:             "test-crn",
+	Network:         "test-network",
+	Cores:           2,
+	Memory:          4,
+	Disk:            10,
+	System:          "test-system",
+	UserData:        "test-user-data",
+	ProcType:        "test-proc-type",
+}
+
+func setupClientAndConfig(config IBMPowerDynamicConfig) (client.Client, *IBMPowerDynamicConfig) {
+	scheme := runtime.NewScheme()
+	_ = pipelinev1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	objs := []client.Object{}
+	objs = append(objs, &v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: config.SystemNamespace,
+		},
+	})
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return client, &config
+}
+
+var _ = Describe("IBM PowerPC Tests", func() {
+
+	client, _ := setupClientAndConfig(config)
+
+	DescribeTable("IBM PowerPC Connection Test",
+		func(instanceId string, expectedError string) {
+			service, err := config.authenticatedService(context.Background(), client)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = service.GetInstanceAddress(context.Background(), instanceId)
+			if expectedError != "" {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(expectedError))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("Positive test", "test-instance-id", ""),
+		Entry("Negative test - instance not found", "non-existent-instance-id", "not found"),
+		Entry("Negative test - invalid instance id", "invalid-instance-id!", "not found"),
+		Entry("Negative test - instance id with special characters", "test-instance-id!@#$%^&amp;*()", "not found"),
+		Entry("Negative test - empty instance ID", "", "instance ID cannot be empty"),
+		Entry("Negative test - nil service", nil, "service is nil"),
+		Entry("Negative test - nil instance ID", nil, "instance ID is nil"),
+	)
+})

--- a/pkg/ibm/ibmp_test.go
+++ b/pkg/ibm/ibmp_test.go
@@ -1,71 +1,69 @@
 package ibm
 
 import (
-	"context"
+	"encoding/base64"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var config = IBMPowerDynamicConfig{
-	SystemNamespace: "test-namespace",
-	Secret:          "test-secret",
-	Key:             "test-key",
-	Image:           "test-image",
-	Url:             "test-url",
-	CRN:             "test-crn",
-	Network:         "test-network",
-	Cores:           2,
-	Memory:          4,
-	Disk:            10,
-	System:          "test-system",
-	UserData:        "test-user-data",
-	ProcType:        "test-proc-type",
+const systemNamespace = "multi-platform-controller"
+
+func parseFloat(s string) float64 {
+	f, err := strconv.ParseFloat(s, 64)
+	Expect(err).NotTo(HaveOccurred())
+	return f
 }
 
-func setupClientAndConfig(config IBMPowerDynamicConfig) (client.Client, *IBMPowerDynamicConfig) {
-	scheme := runtime.NewScheme()
-	_ = pipelinev1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	objs := []client.Object{}
-	objs = append(objs, &v1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
-			Name: config.SystemNamespace,
-		},
-	})
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-	return client, &config
-}
+var _ = DescribeTable("IBMPowerProvider unit test",
+	func(platform string, testConfig map[string]string, expectedCores string, expectedMemory string, expectedDisk string) {
+		config := map[string]string{
+			"dynamic." + platform + ".key":       "test-key",
+			"dynamic." + platform + ".image":     "test-image",
+			"dynamic." + platform + ".secret":    "test-secret",
+			"dynamic." + platform + ".url":       "test-url",
+			"dynamic." + platform + ".crn":       "test-crn",
+			"dynamic." + platform + ".network":   "test-network",
+			"dynamic." + platform + ".system":    "test-system",
+			"dynamic." + platform + ".user-data": "test-userData",
+			"dynamic." + platform + ".memory":    testConfig["memory"],
+			"dynamic." + platform + ".cores":     testConfig["cores"],
+			"dynamic." + platform + ".disk":      testConfig["disk"]}
 
-var _ = Describe("IBM PowerPC Tests", func() {
+		provider := IBMPowerProvider(platform, config, systemNamespace)
+		Expect(provider).ToNot(BeNil())
+		providerConfig := provider.(IBMPowerDynamicConfig)
+		Expect(providerConfig).ToNot(BeNil())
 
-	client, _ := setupClientAndConfig(config)
+		Expect(providerConfig.Key).To(Equal("test-key"))
+		Expect(providerConfig.Image).To(Equal("test-image"))
+		Expect(providerConfig.Secret).To(Equal("test-secret"))
+		Expect(providerConfig.Url).To(Equal("test-url"))
+		Expect(providerConfig.CRN).To(Equal("test-crn"))
+		Expect(providerConfig.Network).To(Equal("test-network"))
+		Expect(providerConfig.System).To(Equal("test-system"))
+		Expect(providerConfig.UserData).To(Equal(base64.StdEncoding.EncodeToString([]byte("test-userData"))))
+		Expect(providerConfig.Cores).To(Equal(parseFloat(expectedCores)))
+		Expect(providerConfig.Memory).To(Equal(parseFloat(expectedMemory)))
+		Expect(providerConfig.Disk).To(Equal(parseFloat(expectedDisk)))
+		Expect(providerConfig.SystemNamespace).To(Equal(systemNamespace))
+	},
 
-	DescribeTable("IBM PowerPC Connection Test",
-		func(instanceId string, expectedError string) {
-			service, err := config.authenticatedService(context.Background(), client)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = service.GetInstanceAddress(context.Background(), instanceId)
-			if expectedError != "" {
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(expectedError))
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-			}
-		},
-		Entry("Positive test", "test-instance-id", ""),
-		Entry("Negative test - instance not found", "non-existent-instance-id", "not found"),
-		Entry("Negative test - invalid instance id", "invalid-instance-id!", "not found"),
-		Entry("Negative test - instance id with special characters", "test-instance-id!@#$%^&amp;*()", "not found"),
-		Entry("Negative test - empty instance ID", "", "instance ID cannot be empty"),
-		Entry("Negative test - nil service", nil, "service is nil"),
-		Entry("Negative test - nil instance ID", nil, "instance ID is nil"),
-	)
-})
+	Entry("Positive - valid config map keys", "power-rhtap-prod-2", map[string]string{
+		"memory": "10.0",
+		"cores":  "2.0",
+		"disk":   "100"}, "2.0", "10.0", "100"),
+	Entry("Negative - nonexistant platform name", "koko-hazamar", map[string]string{
+		"memory": "10.0",
+		"cores":  "2.0",
+		"disk":   "300"}, "2.0", "10.0", "300"),
+	Entry("Negative - missing config data", "ppc6", map[string]string{
+		"memory": "",
+		"cores":  "",
+		"disk":   ""}, "0.25", "2", "100"),
+	Entry("Negative - non-numeral config data", "ppc6", map[string]string{
+		"memory": "koko-hazamar",
+		"cores":  "koko-hazamar",
+		"disk":   "koko-hazamar"}, "0.25", "2", "100"),
+)

--- a/pkg/ibm/ibmp_test.go
+++ b/pkg/ibm/ibmp_test.go
@@ -1,3 +1,15 @@
+//Testing IBMPowerProvider - that provides a IBMPowerDynamicConfig for creating an IBMPowerPC machine for tasks.
+// The spec checks that:
+//	- Configuration data is passed to IBMPowerDynamicConfig correctly when the values are valid
+//  - Default values are inserted whenever the configuration written to host-config.yaml are problematic in structure or value
+//
+// There are 5 test cases:
+// 	1. A positive test to verify all is working correctly with valid config map keys
+//	2. A negative test with a platform name unlike any the MPC covers
+//	3. A negative test to verify default value completion - empty memory, core number and disk size values
+//	4. A negative test to verify default value completion - non-numeric memory, core number and disk size values
+//	5. A negative test to verify default value completion - Verifying disk size default number of 100 if the configuration aims for less than that
+
 package ibm
 
 import (
@@ -17,7 +29,7 @@ func parseFloat(s string) float64 {
 }
 
 var _ = DescribeTable("IBMPowerProvider unit test",
-	func(platform string, testConfig map[string]string, expectedCores string, expectedMemory string, expectedDisk string) {
+	func(platform string, testConfig map[string]string, expectedMemory string, expectedCores string, expectedDisk string) {
 		config := map[string]string{
 			"dynamic." + platform + ".key":       "test-key",
 			"dynamic." + platform + ".image":     "test-image",
@@ -51,19 +63,23 @@ var _ = DescribeTable("IBMPowerProvider unit test",
 	},
 
 	Entry("Positive - valid config map keys", "power-rhtap-prod-2", map[string]string{
-		"memory": "10.0",
-		"cores":  "2.0",
-		"disk":   "100"}, "2.0", "10.0", "100"),
+		"memory": "64.0",
+		"cores":  "8.0",
+		"disk":   "300"}, "64.0", "8.0", "300"),
 	Entry("Negative - nonexistant platform name", "koko-hazamar", map[string]string{
-		"memory": "10.0",
-		"cores":  "2.0",
-		"disk":   "300"}, "2.0", "10.0", "300"),
+		"memory": "64.0",
+		"cores":  "8.0",
+		"disk":   "300"}, "64.0", "8.0", "300"),
 	Entry("Negative - missing config data", "ppc6", map[string]string{
 		"memory": "",
 		"cores":  "",
-		"disk":   ""}, "0.25", "2", "100"),
+		"disk":   ""}, "2", "0.25", "100"),
 	Entry("Negative - non-numeral config data", "ppc6", map[string]string{
 		"memory": "koko-hazamar",
 		"cores":  "koko-hazamar",
-		"disk":   "koko-hazamar"}, "0.25", "2", "100"),
+		"disk":   "koko-hazamar"}, "2", "0.25", "100"),
+	Entry("Negative - disk size too small", "power-rhtap-prod-2", map[string]string{
+		"memory": "64.0",
+		"cores":  "8.0",
+		"disk":   "42"}, "64.0", "8.0", "100"),
 )


### PR DESCRIPTION
A unit test for IBMPowerProvider, in ibmp.go, which check both correct fields and the way it handles faulty configuration data entry. 
The rest of the functions in this file should really be tested as part of the [cloud provider testing effort ](https://issues.redhat.com/browse/KFLUXINFRA-1065) which will begin after the unit test epic is done. 

The spec checks that:
  - Configuration data is passed to IBMPowerDynamicConfig correctly when the values are valid
  - Default values are inserted whenever the configuration written to host-config.yaml are problematic in structure or value
 There are 5 test cases:
    1. A positive test to verify all is working correctly with valid config map keys
    2. A negative test with a platform name unlike any the MPC covers
    3. A negative test to verify default value completion - empty memory, core number and disk size values
    4. A negative test to verify default value completion - non-numeric memory, core number and disk size values
    5. A negative test to verify default value completion - Verifying disk size default number of 100 if the configuration aims for less than that.

Also in this commit - a fix for the aws tests :)
