### PR TITLE
Add partition and filesystem resize for PPC custom volumes size

### DIFF
--- a/deploy/operator/provision-shared-host.yaml
+++ b/deploy/operator/provision-shared-host.yaml
@@ -48,6 +48,14 @@ spec:
         set -o verbose
         set -eu
         set -o pipefail
+        # resize the root partition & filesystem if needed (ppc64le only)
+        if  [ "$(uname -m)" == "ppc64le" ]; then
+          echo "Resizing root partition"
+          DRIVE="$(fdisk -l 2>/dev/null |awk '/^Disk \/dev\/mapper/ {print substr($2,0,length($2)-1)}')"
+          echo yes | parted $DRIVE---pretend-input-tty resizepart 3 100%
+          partprobe $DRIVE
+          xfs_growfs /
+        fi
         mkdir -p /root/.ssh
         cp $(workspaces.ssh.path)/id_rsa /tmp/master_key
         chmod 0400 /tmp/master_key

--- a/deploy/operator/provision-shared-host.yaml
+++ b/deploy/operator/provision-shared-host.yaml
@@ -48,14 +48,6 @@ spec:
         set -o verbose
         set -eu
         set -o pipefail
-        # resize the root partition & filesystem if needed (ppc64le only)
-        if  [ "$(uname -m)" == "ppc64le" ]; then
-          echo "Resizing root partition"
-          DRIVE="$(fdisk -l 2>/dev/null |awk '/^Disk \/dev\/mapper/ {print substr($2,0,length($2)-1)}')"
-          echo yes | parted $DRIVE---pretend-input-tty resizepart 3 100%
-          partprobe $DRIVE
-          xfs_growfs /
-        fi
         mkdir -p /root/.ssh
         cp $(workspaces.ssh.path)/id_rsa /tmp/master_key
         chmod 0400 /tmp/master_key
@@ -64,6 +56,15 @@ spec:
         export USERNAME=u-$(echo "$TASKRUN_NAME$NAMESPACE" | md5sum | cut -b-28)
         
         cat >script.sh <<EOF
+        # resize the root partition & filesystem if needed (ppc64le only)
+        if  [ "$(uname -m)" == "ppc64le" ]; then
+          echo "Resizing root partition"
+          DRIVE="$(fdisk -l 2>/dev/null |awk '/^Disk \/dev\/mapper/ {print substr($2,0,length($2)-1)}')"
+          echo yes | parted $DRIVE---pretend-input-tty resizepart 3 100%
+          partprobe $DRIVE
+          xfs_growfs /
+        fi
+
         sudo dnf install podman -y
         rm -f $USERNAME $USERNAME.pub
         # sometimes it hits  "useradd: cannot lock /etc/passwd; try again later" error, so need to repeat

--- a/deploy/operator/provision-shared-host.yaml
+++ b/deploy/operator/provision-shared-host.yaml
@@ -60,7 +60,7 @@ spec:
         if  [ "$(uname -m)" == "ppc64le" ]; then
           echo "Resizing root partition"
           DRIVE="$(fdisk -l 2>/dev/null |awk '/^Disk \/dev\/mapper/ {print substr($2,0,length($2)-1)}')"
-          echo yes | parted $DRIVE---pretend-input-tty resizepart 3 100%
+          echo yes | parted $DRIVE ---pretend-input-tty resizepart 3 100%
           partprobe $DRIVE
           xfs_growfs /
         fi


### PR DESCRIPTION
Resizing the volume on-the-fly only resizes the disk, but partition and filesystem remain the same size.
They need to be aligned manually.
Those commands does not affect stardard size volumes (is no resize applied).
Fixes  https://issues.redhat.com/browse/KONFLUX-6560