### PR TITLE
IBM System Z Cloud Provider code cleanup (part 2)

### DIFF
--- a/pkg/ibm/ibmz.go
+++ b/pkg/ibm/ibmz.go
@@ -6,27 +6,21 @@ import (
 	// strength doesn't matter here
 	"crypto/md5" //#nosec
 	"encoding/base64"
-	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
-	v1 "k8s.io/api/core/v1"
-	types2 "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// IBMZProvider returns an IBM System Z cloud configuration that implements the CloudProvider interface.
-func IBMZProvider(arch string, config map[string]string, systemNamespace string) cloud.CloudProvider {
+// CreateIbmZCloudConfig returns an IBM System Z cloud configuration that implements the CloudProvider interface.
+func CreateIbmZCloudConfig(arch string, config map[string]string, systemNamespace string) cloud.CloudProvider {
 	privateIp, _ := strconv.ParseBool(config["dynamic."+arch+".private-ip"])
 	volumeSize, err := strconv.Atoi(config["dynamic."+arch+".disk"])
 	if err != nil {
@@ -49,54 +43,54 @@ func IBMZProvider(arch string, config map[string]string, systemNamespace string)
 
 // LaunchInstance creates a System Z Virtual Server instance and returns its identifier. This function is implemented as
 // part of the CloudProvider interface, which is why some of the arguments are unused for this particular implementation.
-func (r IBMZDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunName string, instanceTag string, _ map[string]string) (cloud.InstanceIdentifier, error) {
-	vpcService, err := r.authenticatedService(ctx, kubeClient)
+func (ibmz IBMZDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunName string, instanceTag string, _ map[string]string) (cloud.InstanceIdentifier, error) {
+	vpcService, err := ibmz.authenticatedService(ctx, kubeClient)
 	if err != nil {
 		return "", fmt.Errorf("failed to create an authenticated VPC service: %w", err)
 	}
 
 	binary, err := uuid.New().MarshalBinary()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create a UUID for the instance name: %w", err)
 	}
 	// #nosec is added to bypass the golang security scan since the cryptographic
 	// strength doesn't matter here
 	md5EncodedBinary := md5.New().Sum(binary) //#nosec
 	md5EncodedString := base64.URLEncoding.EncodeToString(md5EncodedBinary)[0:20]
-	name := instanceTag + "-" + strings.Replace(strings.ToLower(md5EncodedString), "_", "-", -1) + "x"
+	instanceName := instanceTag + "-" + strings.Replace(strings.ToLower(md5EncodedString), "_", "-", -1) + "x"
 
 	// Gather required information for the VPC instance
-	vpc, err := r.lookupVpc(vpcService)
+	vpc, err := ibmz.lookupVpc(vpcService)
 	if err != nil {
 		return "", err
 	}
 
-	key, err := r.lookupSSHKey(vpcService)
+	key, err := ibmz.lookupSSHKey(vpcService)
 	if err != nil {
 		return "", err
 	}
 
-	image := r.ImageId
-	subnet, err := r.lookupSubnet(vpcService)
+	image := ibmz.ImageId
+	subnet, err := ibmz.lookupSubnet(vpcService)
 	if err != nil {
 		return "", err
 	}
 
-	result, _, err := vpcService.CreateInstance(&vpcv1.CreateInstanceOptions{
+	vpcInstance, _, err := vpcService.CreateInstance(&vpcv1.CreateInstanceOptions{
 		InstancePrototype: &vpcv1.InstancePrototype{
-			Name: &name,
-			Zone: &vpcv1.ZoneIdentityByName{Name: ptr(r.Region)},
+			Name: &instanceName,
+			Zone: &vpcv1.ZoneIdentityByName{Name: ptr(ibmz.Region)},
 			ResourceGroup: &vpcv1.ResourceGroupIdentity{
 				ID: vpc.ResourceGroup.ID,
 			},
 			VPC:     &vpcv1.VPCIdentityByID{ID: vpc.ID},
-			Profile: &vpcv1.InstanceProfileIdentityByName{Name: ptr(r.Profile)},
+			Profile: &vpcv1.InstanceProfileIdentityByName{Name: ptr(ibmz.Profile)},
 			Keys:    []vpcv1.KeyIdentityIntf{&vpcv1.KeyIdentity{ID: key.ID}},
 			BootVolumeAttachment: &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
 				DeleteVolumeOnInstanceDelete: ptr(true),
 				Volume: &vpcv1.VolumePrototypeInstanceByImageContext{
-					Name:     ptr(name + "-volume"),
-					Capacity: ptr(int64(r.Disk)),
+					Name:     ptr(instanceName + "-volume"),
+					Capacity: ptr(int64(ibmz.Disk)),
 					Profile: &vpcv1.VolumeProfileIdentity{
 						Name: ptr("general-purpose"),
 					},
@@ -123,27 +117,27 @@ func (r IBMZDynamicConfig) LaunchInstance(kubeClient client.Client, ctx context.
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create the System Z virtual server instance %s: %w", name, err)
+		return "", fmt.Errorf("failed to create the System Z virtual server instance %s: %w", instanceName, err)
 	}
 
-	return cloud.InstanceIdentifier(*result.ID), nil
+	return cloud.InstanceIdentifier(*vpcInstance.ID), nil
 
 }
 
 // CountInstances returns the number of System Z virtual server instances whose names start with instanceTag.
-func (r IBMZDynamicConfig) CountInstances(kubeClient client.Client, ctx context.Context, instanceTag string) (int, error) {
-	vpcService, err := r.authenticatedService(ctx, kubeClient)
+func (ibmz IBMZDynamicConfig) CountInstances(kubeClient client.Client, ctx context.Context, instanceTag string) (int, error) {
+	vpcService, err := ibmz.authenticatedService(ctx, kubeClient)
 	if err != nil {
 		return -1, fmt.Errorf("failed to create an authenticated VPC service: %w", err)
 	}
 
-	vpc, err := r.lookupVpc(vpcService)
+	vpc, err := ibmz.lookupVpc(vpcService)
 	if err != nil {
 		return -1, err
 	}
-	instances, _, err := vpcService.ListInstances(&vpcv1.ListInstancesOptions{ResourceGroupID: vpc.ResourceGroup.ID, VPCName: &r.Vpc})
+	instances, _, err := vpcService.ListInstances(&vpcv1.ListInstancesOptions{ResourceGroupID: vpc.ResourceGroup.ID, VPCName: &ibmz.Vpc})
 	if err != nil {
-		return -1, fmt.Errorf("failed to list virtual server instances in VPC network %s: %w", r.Vpc, err)
+		return -1, fmt.Errorf("failed to list virtual server instances in VPC network %s: %w", ibmz.Vpc, err)
 	}
 	count := 0
 	for _, instance := range instances.Instances {
@@ -155,155 +149,55 @@ func (r IBMZDynamicConfig) CountInstances(kubeClient client.Client, ctx context.
 }
 
 // ListInstances returns a collection of accessible System Z virtual server instances whose names start with instanceTag.
-func (r IBMZDynamicConfig) ListInstances(kubeClient client.Client, ctx context.Context, instanceTag string) ([]cloud.CloudVMInstance, error) {
-	vpcService, err := r.authenticatedService(ctx, kubeClient)
+func (ibmz IBMZDynamicConfig) ListInstances(kubeClient client.Client, ctx context.Context, instanceTag string) ([]cloud.CloudVMInstance, error) {
+	vpcService, err := ibmz.authenticatedService(ctx, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an authenticated VPC service: %w", err)
 	}
 
-	vpc, err := r.lookupVpc(vpcService)
+	vpc, err := ibmz.lookupVpc(vpcService)
 	if err != nil {
 		return nil, err
 	}
 
-	instances, _, err := vpcService.ListInstances(&vpcv1.ListInstancesOptions{ResourceGroupID: vpc.ResourceGroup.ID, VPCName: &r.Vpc})
+	vpcInstances, _, err := vpcService.ListInstances(&vpcv1.ListInstancesOptions{ResourceGroupID: vpc.ResourceGroup.ID, VPCName: &ibmz.Vpc})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list VPC instances in the VPC network %s: %w", *vpc.ID, err)
 	}
 
-	ret := []cloud.CloudVMInstance{}
+	vmInstances := []cloud.CloudVMInstance{}
 	log := logr.FromContextOrDiscard(ctx)
 
 	// Ensure all listed instances have a reachable IP address
-	for _, instance := range instances.Instances {
+	for _, instance := range vpcInstances.Instances {
 		if strings.HasPrefix(*instance.Name, instanceTag) {
-			addr, err := r.instanceIP(ctx, &instance, kubeClient)
+			addr, err := ibmz.instanceIP(ctx, &instance, kubeClient)
 			if err != nil {
-				log.Error(err, "not listing instance as address cannot be assigned yet", "instance", *instance.ID)
+				log.Error(err, "not listing instance as IP address cannot be assigned yet", "instance", *instance.ID)
 				continue
 			}
 			if err := checkAddressLive(ctx, addr); err != nil {
-				log.Error(err, "not listing instance as address cannot be accessed yet", "instance", *instance.ID)
+				log.Error(err, "not listing instance as IP address cannot be accessed yet", "instance", *instance.ID)
 				continue
 			}
-			ret = append(ret, cloud.CloudVMInstance{
+			newVmInstance := cloud.CloudVMInstance{
 				InstanceId: cloud.InstanceIdentifier(*instance.ID),
 				Address:    addr,
 				StartTime:  time.Time(*instance.CreatedAt),
-			})
+			}
+			vmInstances = append(vmInstances, newVmInstance)
 		}
 	}
-	return ret, nil
-}
-
-// lookupSubnet looks for ibmz's subnet in the provided IBM Virtual Private Cloud service's API.
-// Either the corresponding subnet or an error with a nil object is returned.
-func (r IBMZDynamicConfig) lookupSubnet(vpcService *vpcv1.VpcV1) (*vpcv1.Subnet, error) {
-	subnets, _, err := vpcService.ListSubnets(&vpcv1.ListSubnetsOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	var subnet *vpcv1.Subnet
-	for i := range subnets.Subnets {
-		if *subnets.Subnets[i].Name == r.Subnet {
-			subnet = &subnets.Subnets[i]
-			break
-		}
-	}
-	if subnet == nil {
-		return nil, fmt.Errorf("failed to find subnet %s", r.Subnet)
-	}
-	return subnet, nil
-}
-
-// lookupSSHKey looks for ibmz's SSH key in the provided IBM Virtual Private Cloud service's API.
-// Either the corresponding key or an error with a nil object is returned.
-func (r IBMZDynamicConfig) lookupSSHKey(vpcService *vpcv1.VpcV1) (*vpcv1.Key, error) {
-	keys, _, err := vpcService.ListKeys(&vpcv1.ListKeysOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	var key *vpcv1.Key
-	for i := range keys.Keys {
-		if *keys.Keys[i].Name == r.Key {
-			key = &keys.Keys[i]
-			break
-		}
-	}
-	if key == nil {
-		return nil, fmt.Errorf("failed to find SSH key %s", r.Key)
-	}
-	return key, nil
-}
-
-// lookUpVpc looks for ibmz's VPC network in the provided IBM Virtual Private Cloud service's API.
-// Either the corresponding VPC network or an error with a nil object is returned.
-func (r IBMZDynamicConfig) lookupVpc(vpcService *vpcv1.VpcV1) (*vpcv1.VPC, error) {
-	vpcs, _, err := vpcService.ListVpcs(&vpcv1.ListVpcsOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	var vpc *vpcv1.VPC
-	for i := range vpcs.Vpcs {
-		//println("VPC: " + *vpcs.Vpcs[i].Name)
-		if *vpcs.Vpcs[i].Name == r.Vpc {
-			vpc = &vpcs.Vpcs[i]
-			break
-		}
-	}
-	if vpc == nil {
-		return nil, fmt.Errorf("failed to find VPC %s", r.Vpc)
-	}
-	return vpc, nil
-}
-
-func ptr[V any](s V) *V {
-	return &s
-}
-
-// authenticatedService generates a Virtual Private Cloud service with an API key-based IAM (Identity and Access
-// Management) authenticator.
-func (r IBMZDynamicConfig) authenticatedService(ctx context.Context, kubeClient client.Client) (*vpcv1.VpcV1, error) {
-	apiKey := ""
-	if kubeClient == nil { // Get API key from an environment variable
-		apiKey = os.Getenv("IBM_CLOUD_API_KEY")
-		if apiKey == "" {
-			return nil, errors.New("the API key from the IBM_CLOUD_API_KEY environment variable was empty")
-		}
-	} else { // Get API key from the ibmz Kubernetes Secret
-		s := v1.Secret{}
-		nameSpacedSecret := types2.NamespacedName{Name: r.Secret, Namespace: r.SystemNamespace}
-		err := kubeClient.Get(ctx, nameSpacedSecret, &s)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve the secret %s from the Kubernetes client: %w", nameSpacedSecret, err)
-		}
-
-		apiKeyByte, ok := s.Data["api-key"]
-		if !ok {
-			return nil, fmt.Errorf("the secret %s did not have an API key field", nameSpacedSecret)
-		}
-		apiKey = string(apiKeyByte)
-	}
-
-	// Instantiate the VPC service
-	vpcService, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{
-		URL: r.Url,
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: apiKey,
-		},
-	})
-	return vpcService, err
+	log.Info("Finished listing VPC instances.", "count", len(vmInstances))
+	return vmInstances, nil
 }
 
 // GetInstanceAddress returns the IP Address associated with the instanceID System Z virtual server instance.
-func (r IBMZDynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
+func (ibmz IBMZDynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
 	log := logr.FromContextOrDiscard(ctx)
-	vpcService, err := r.authenticatedService(ctx, kubeClient)
+	vpcService, err := ibmz.authenticatedService(ctx, kubeClient)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create an authenticated VPC service: %w", err)
 	}
 
 	instance, _, err := vpcService.GetInstance(&vpcv1.GetInstanceOptions{ID: ptr(string(instanceId))})
@@ -311,10 +205,10 @@ func (r IBMZDynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx cont
 		return "", nil // TODO: clarify comment -> not permanent, this can take a while to appear
 	}
 
-	ip, err := r.instanceIP(ctx, instance, kubeClient)
+	ip, err := ibmz.instanceIP(ctx, instance, kubeClient)
 	if err != nil {
-		log.Error(err, "Failed to lookup IP", "instanceId", instanceId, "error", err.Error())
-		return "", err
+		log.Error(err, "failed to lookup IP address", "instanceId", instanceId)
+		return "", fmt.Errorf("failed to look up/assign an IP address for instance %s: %w", instanceId, err)
 	}
 	if ip != "" {
 		if err = checkAddressLive(ctx, ip); err != nil {
@@ -324,121 +218,12 @@ func (r IBMZDynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx cont
 	return ip, nil
 }
 
-func (r IBMZDynamicConfig) instanceIP(ctx context.Context, instance *vpcv1.Instance, kubeClient client.Client) (string, error) {
-
-	if r.PrivateIP {
-		for _, i := range instance.NetworkInterfaces {
-			if i.PrimaryIP != nil && i.PrimaryIP.Address != nil && *i.PrimaryIP.Address != "0.0.0.0" {
-				return *i.PrimaryIP.Address, nil
-			}
-		}
-		return "", nil
-	}
-
-	vpcService, err := r.authenticatedService(ctx, kubeClient)
-	if err != nil {
-		return "", err
-	}
-
-	// Try to get an IP address that is already associated with the instance
-	// network interface.
-	ips, _, err := vpcService.ListInstanceNetworkInterfaceFloatingIps(
-		&vpcv1.ListInstanceNetworkInterfaceFloatingIpsOptions{
-			InstanceID:         instance.ID,
-			NetworkInterfaceID: instance.PrimaryNetworkInterface.ID,
-		},
-	)
-	if err != nil {
-		return "", nil // TODO: clarify comment -> not permanent, this can take a while to appear
-	}
-	if len(ips.FloatingIps) > 0 {
-		return *ips.FloatingIps[0].Address, nil
-	}
-
-	// If no IPs associated with an instance network interface are found, ensure the VPC instance is not in an
-	// undesireable state before looking for a floating IP in the region
-	switch *instance.Status {
-	case vpcv1.InstanceStatusDeletingConst:
-		return "", fmt.Errorf("instance was deleted")
-	case vpcv1.InstanceStatusFailedConst:
-		return "", fmt.Errorf("instance failed")
-	case vpcv1.InstanceStatusPendingConst:
-		return "", nil
-	case vpcv1.InstanceStatusRestartingConst:
-		return "", nil
-	case vpcv1.InstanceStatusStartingConst:
-		return "", nil
-	case vpcv1.InstanceStatusStoppedConst:
-		return "", fmt.Errorf("instance was stopped")
-	case vpcv1.InstanceStatusStoppingConst:
-		return "", fmt.Errorf("instance was stopping")
-	}
-
-	// Try to find a floating IP address in the region.
-	existingIps, _, err := vpcService.ListFloatingIps(&vpcv1.ListFloatingIpsOptions{ResourceGroupID: instance.ResourceGroup.ID})
-	if err != nil {
-		return "", err
-	}
-	for _, ip := range existingIps.FloatingIps {
-		if *ip.Status == vpcv1.FloatingIPStatusAvailableConst {
-			_, _, err = vpcService.AddInstanceNetworkInterfaceFloatingIP(
-				&vpcv1.AddInstanceNetworkInterfaceFloatingIPOptions{
-					InstanceID:         instance.ID,
-					NetworkInterfaceID: instance.PrimaryNetworkInterface.ID,
-					ID:                 ip.ID,
-				})
-			if err != nil {
-				return "", err
-			}
-			return *ip.Address, nil
-		}
-
-	}
-
-	// As a last resort, allocate a new IP Address. This is very expensive, as if we allocate a new IP address,
-	// we are charged for the full month TODO: clarify this portion of comment -> (60c)
-	ip, _, err := vpcService.CreateFloatingIP(&vpcv1.CreateFloatingIPOptions{FloatingIPPrototype: &vpcv1.FloatingIPPrototype{
-		Zone: &vpcv1.ZoneIdentityByName{Name: ptr("us-east-2")},
-		ResourceGroup: &vpcv1.ResourceGroupIdentity{
-			ID: instance.ResourceGroup.ID,
-		}}})
-	if err != nil {
-		return "", err
-	}
-	_, _, err = vpcService.AddInstanceNetworkInterfaceFloatingIP(
-		&vpcv1.AddInstanceNetworkInterfaceFloatingIPOptions{
-			InstanceID: instance.ID, NetworkInterfaceID: instance.PrimaryNetworkInterface.ID,
-			ID: ip.ID,
-		})
-	if err != nil {
-		return "", err
-	}
-	return *ip.Address, nil
-}
-
-// checkIfIpIsLive tries to resolve the IP address ip. An
-// error is returned if ip couldn't be reached.
-func checkAddressLive(ctx context.Context, addr string) error {
-	log := logr.FromContextOrDiscard(ctx)
-	log.Info(fmt.Sprintf("checking if address %s is live", addr))
-
-	server, _ := net.ResolveTCPAddr("tcp", addr+":22")
-	conn, err := net.DialTimeout(server.Network(), server.String(), 5*time.Second)
-	if err != nil {
-		log.Info("failed to connect to IBM host " + addr)
-		return err
-	}
-	defer conn.Close()
-	return nil
-
-}
-
 // TerminateInstance tries to delete a specific System Z virtual server instance for 10 minutes or until the instance is deleted.
-func (r IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) error {
+func (ibmz IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) error {
 	log := logr.FromContextOrDiscard(ctx)
-	vpcService, err := r.authenticatedService(context.Background(), kubeClient)
+	vpcService, err := ibmz.authenticatedService(context.Background(), kubeClient)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create an authenticated VPC service: %w", err)
 	}
 
 	// Iterate for 10 minutes
@@ -451,7 +236,7 @@ func (r IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx conte
 			if err != nil {
 				// Log an error if it's the first iteration or there is a non-404 code response
 				if repeats == 0 || (resp != nil && resp.StatusCode != http.StatusNotFound) {
-					log.Error(err, "failed to delete System Z instance, unable to get instance", "instanceId", *instance.ID)
+					log.Error(err, "failed to delete System Z instance; unable to get instance", "instanceId", *instance.ID)
 				}
 				return
 			}
@@ -468,7 +253,7 @@ func (r IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx conte
 
 			_, err = vpcService.DeleteInstanceWithContext(localCtx, &vpcv1.DeleteInstanceOptions{ID: instance.ID})
 			if err != nil {
-				log.Error(err, "failed to VPC instance", "instanceID", *instance.ID)
+				log.Error(err, "failed to System Z instance", "instanceID", *instance.ID)
 			}
 			if timeout.Before(time.Now()) {
 				return
@@ -482,7 +267,7 @@ func (r IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx conte
 	return nil
 }
 
-func (r IBMZDynamicConfig) SshUser() string {
+func (ibmz IBMZDynamicConfig) SshUser() string {
 	return "root"
 }
 

--- a/pkg/ibm/ibmz_helpers.go
+++ b/pkg/ibm/ibmz_helpers.go
@@ -1,0 +1,228 @@
+package ibm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	types2 "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// lookupSubnet looks for ibmz's subnet in the provided IBM Virtual Private Cloud service's API.
+// Either the corresponding subnet or an error with a nil object is returned.
+func (r IBMZDynamicConfig) lookupSubnet(vpcService *vpcv1.VpcV1) (*vpcv1.Subnet, error) {
+	subnets, _, err := vpcService.ListSubnets(&vpcv1.ListSubnetsOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var subnet *vpcv1.Subnet
+	for i := range subnets.Subnets {
+		if *subnets.Subnets[i].Name == r.Subnet {
+			subnet = &subnets.Subnets[i]
+			break
+		}
+	}
+	if subnet == nil {
+		return nil, fmt.Errorf("failed to find subnet %s", r.Subnet)
+	}
+	return subnet, nil
+}
+
+// lookupSSHKey looks for ibmz's SSH key in the provided IBM Virtual Private Cloud service's API.
+// Either the corresponding key or an error with a nil object is returned.
+func (r IBMZDynamicConfig) lookupSSHKey(vpcService *vpcv1.VpcV1) (*vpcv1.Key, error) {
+	keys, _, err := vpcService.ListKeys(&vpcv1.ListKeysOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var key *vpcv1.Key
+	for i := range keys.Keys {
+		if *keys.Keys[i].Name == r.Key {
+			key = &keys.Keys[i]
+			break
+		}
+	}
+	if key == nil {
+		return nil, fmt.Errorf("failed to find SSH key %s", r.Key)
+	}
+	return key, nil
+}
+
+// lookUpVpc looks for ibmz's VPC network in the provided IBM Virtual Private Cloud service's API.
+// Either the corresponding VPC network or an error with a nil object is returned.
+func (r IBMZDynamicConfig) lookupVpc(vpcService *vpcv1.VpcV1) (*vpcv1.VPC, error) {
+	vpcs, _, err := vpcService.ListVpcs(&vpcv1.ListVpcsOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var vpc *vpcv1.VPC
+	for i := range vpcs.Vpcs {
+		//println("VPC: " + *vpcs.Vpcs[i].Name)
+		if *vpcs.Vpcs[i].Name == r.Vpc {
+			vpc = &vpcs.Vpcs[i]
+			break
+		}
+	}
+	if vpc == nil {
+		return nil, fmt.Errorf("failed to find VPC %s", r.Vpc)
+	}
+	return vpc, nil
+}
+
+func ptr[V any](s V) *V {
+	return &s
+}
+
+// authenticatedService generates a Virtual Private Cloud service with an API key-based IAM (Identity and Access
+// Management) authenticator.
+func (r IBMZDynamicConfig) authenticatedService(ctx context.Context, kubeClient client.Client) (*vpcv1.VpcV1, error) {
+	apiKey := ""
+	if kubeClient == nil { // Get API key from an environment variable
+		apiKey = os.Getenv("IBM_CLOUD_API_KEY")
+		if apiKey == "" {
+			return nil, errors.New("the API key from the IBM_CLOUD_API_KEY environment variable was empty")
+		}
+	} else { // Get API key from the ibmz Kubernetes Secret
+		s := v1.Secret{}
+		nameSpacedSecret := types2.NamespacedName{Name: r.Secret, Namespace: r.SystemNamespace}
+		err := kubeClient.Get(ctx, nameSpacedSecret, &s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve the secret %s from the Kubernetes client: %w", nameSpacedSecret, err)
+		}
+
+		apiKeyByte, ok := s.Data["api-key"]
+		if !ok {
+			return nil, fmt.Errorf("the secret %s did not have an API key field", nameSpacedSecret)
+		}
+		apiKey = string(apiKeyByte)
+	}
+
+	// Instantiate the VPC service
+	vpcService, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{
+		URL: r.Url,
+		Authenticator: &core.IamAuthenticator{
+			ApiKey: apiKey,
+		},
+	})
+	return vpcService, err
+}
+
+func (r IBMZDynamicConfig) instanceIP(ctx context.Context, instance *vpcv1.Instance, kubeClient client.Client) (string, error) {
+
+	if r.PrivateIP {
+		for _, i := range instance.NetworkInterfaces {
+			if i.PrimaryIP != nil && i.PrimaryIP.Address != nil && *i.PrimaryIP.Address != "0.0.0.0" {
+				return *i.PrimaryIP.Address, nil
+			}
+		}
+		return "", nil
+	}
+
+	vpcService, err := r.authenticatedService(ctx, kubeClient)
+	if err != nil {
+		return "", err
+	}
+
+	// Try to get an IP address that is already associated with the instance
+	// network interface.
+	ips, _, err := vpcService.ListInstanceNetworkInterfaceFloatingIps(
+		&vpcv1.ListInstanceNetworkInterfaceFloatingIpsOptions{
+			InstanceID:         instance.ID,
+			NetworkInterfaceID: instance.PrimaryNetworkInterface.ID,
+		},
+	)
+	if err != nil {
+		return "", nil // TODO: clarify comment -> not permanent, this can take a while to appear
+	}
+	if len(ips.FloatingIps) > 0 {
+		return *ips.FloatingIps[0].Address, nil
+	}
+
+	// If no IPs associated with an instance network interface are found, ensure the VPC instance is not in an
+	// undesireable state before looking for a floating IP in the region
+	switch *instance.Status {
+	case vpcv1.InstanceStatusDeletingConst:
+		return "", fmt.Errorf("instance was deleted")
+	case vpcv1.InstanceStatusFailedConst:
+		return "", fmt.Errorf("instance failed")
+	case vpcv1.InstanceStatusPendingConst:
+		return "", nil
+	case vpcv1.InstanceStatusRestartingConst:
+		return "", nil
+	case vpcv1.InstanceStatusStartingConst:
+		return "", nil
+	case vpcv1.InstanceStatusStoppedConst:
+		return "", fmt.Errorf("instance was stopped")
+	case vpcv1.InstanceStatusStoppingConst:
+		return "", fmt.Errorf("instance was stopping")
+	}
+
+	// Try to find a floating IP address in the region.
+	existingIps, _, err := vpcService.ListFloatingIps(&vpcv1.ListFloatingIpsOptions{ResourceGroupID: instance.ResourceGroup.ID})
+	if err != nil {
+		return "", err
+	}
+	for _, ip := range existingIps.FloatingIps {
+		if *ip.Status == vpcv1.FloatingIPStatusAvailableConst {
+			_, _, err = vpcService.AddInstanceNetworkInterfaceFloatingIP(
+				&vpcv1.AddInstanceNetworkInterfaceFloatingIPOptions{
+					InstanceID:         instance.ID,
+					NetworkInterfaceID: instance.PrimaryNetworkInterface.ID,
+					ID:                 ip.ID,
+				})
+			if err != nil {
+				return "", err
+			}
+			return *ip.Address, nil
+		}
+
+	}
+
+	// As a last resort, allocate a new IP Address. This is very expensive, as if we allocate a new IP address,
+	// we are charged for the full month TODO: clarify this portion of comment -> (60c)
+	ip, _, err := vpcService.CreateFloatingIP(&vpcv1.CreateFloatingIPOptions{FloatingIPPrototype: &vpcv1.FloatingIPPrototype{
+		Zone: &vpcv1.ZoneIdentityByName{Name: ptr("us-east-2")},
+		ResourceGroup: &vpcv1.ResourceGroupIdentity{
+			ID: instance.ResourceGroup.ID,
+		}}})
+	if err != nil {
+		return "", err
+	}
+	_, _, err = vpcService.AddInstanceNetworkInterfaceFloatingIP(
+		&vpcv1.AddInstanceNetworkInterfaceFloatingIPOptions{
+			InstanceID: instance.ID, NetworkInterfaceID: instance.PrimaryNetworkInterface.ID,
+			ID: ip.ID,
+		})
+	if err != nil {
+		return "", err
+	}
+	return *ip.Address, nil
+}
+
+// checkIfIpIsLive tries to resolve the IP address ip. An
+// error is returned if ip couldn't be reached.
+func checkAddressLive(ctx context.Context, addr string) error {
+	log := logr.FromContextOrDiscard(ctx)
+	log.Info(fmt.Sprintf("checking if address %s is live", addr))
+
+	server, _ := net.ResolveTCPAddr("tcp", addr+":22")
+	conn, err := net.DialTimeout(server.Network(), server.String(), 5*time.Second)
+	if err != nil {
+		log.Info("failed to connect to IBM host " + addr)
+		return err
+	}
+	defer conn.Close()
+	return nil
+
+}

--- a/pkg/ibm/ibmz_test.go
+++ b/pkg/ibm/ibmz_test.go
@@ -31,7 +31,7 @@ var _ = DescribeTable("IBMZProvider unit test",
 			"dynamic." + arch + ".private-ip":     testConfig["private-ip"],
 			"dynamic." + arch + ".disk":           testConfig["disk"],
 		}
-		provider := IBMZProvider(arch, config, systemNamespace)
+		provider := CreateIbmZCloudConfig(arch, config, systemNamespace)
 		Expect(provider).ToNot(BeNil())
 		providerConfig := provider.(IBMZDynamicConfig)
 		Expect(providerConfig).ToNot(BeNil())

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -112,7 +112,7 @@ func newReconciler(mgr ctrl.Manager, operatorNamespace string) reconcile.Reconci
 		eventRecorder:     mgr.GetEventRecorderFor("MultiPlatformTaskRun"),
 		operatorNamespace: operatorNamespace,
 		platformConfig:    map[string]PlatformConfig{},
-		cloudProviders:    map[string]func(platform string, config map[string]string, systemNamespace string) cloud.CloudProvider{"aws": aws.Ec2Provider, "ibmz": ibm.IBMZProvider, "ibmp": ibm.IBMPowerProvider},
+		cloudProviders:    map[string]func(platform string, config map[string]string, systemNamespace string) cloud.CloudProvider{"aws": aws.Ec2Provider, "ibmz": ibm.CreateIbmZCloudConfig, "ibmp": ibm.IBMPowerProvider},
 	}
 }
 


### PR DESCRIPTION
* Variables were renamed for clarity
* More error messsages were prefaced with detail for clarity
* Non-CloudProvider interface functions were moved to a helper file