### PR TITLE
Add functionality to re-queue failed IBM VMs

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -252,6 +252,11 @@ func (r AwsEc2DynamicConfig) SshUser() string {
 	return "ec2-user"
 }
 
+// TODO: implement this function.
+func (ec AwsEc2DynamicConfig) GetState(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
+	return "ACTIVE", nil
+}
+
 // An AwsEc2DynamicConfig represents a configuration for an AWS EC2 instance.
 // The zero value (where each field will be assigned its type's zero value) is not a
 // valid AwsEc2DynamicConfig.

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -16,6 +16,7 @@ type CloudProvider interface {
 	GetInstanceAddress(kubeClient client.Client, ctx context.Context, instanceId InstanceIdentifier) (string, error)
 	CountInstances(kubeClient client.Client, ctx context.Context, instanceTag string) (int, error)
 	ListInstances(kubeClient client.Client, ctx context.Context, instanceTag string) ([]CloudVMInstance, error)
+	GetState(kubeClient client.Client, ctx context.Context, instanceId InstanceIdentifier) (string, error)
 	SshUser() string
 }
 

--- a/pkg/ibm/ibmz.go
+++ b/pkg/ibm/ibmz.go
@@ -265,7 +265,23 @@ func (iz IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx cont
 	return nil
 }
 
-func (iz IBMZDynamicConfig) SshUser() string {
+// GetState returns iz's VM state from the IBM VPC service. See https://cloud.ibm.com/apidocs/vpc/latest?code=go#get-instance for
+// valid state strings.
+func (iz IBMZDynamicConfig) GetState(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
+	vpcService, err := iz.createAuthenticatedVpcService(ctx, kubeClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to create an authenticated VPC service: %w", err)
+	}
+
+	instance, _, err := vpcService.GetInstance(&vpcv1.GetInstanceOptions{ID: ptr(string(instanceId))})
+	if err != nil {
+		return "", nil // TODO: clarify comment -> not permanent, this can take a while to appear
+	}
+
+	return *instance.LifecycleState, nil
+}
+
+func (ibmz IBMZDynamicConfig) SshUser() string {
 	return "root"
 }
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -801,6 +801,11 @@ func (m *MockCloud) GetInstanceAddress(kubeClient runtimeclient.Client, ctx cont
 	return addr, nil
 }
 
+// TODO: implement
+func (m *MockCloud) GetState(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
+	return "ACTIVE", nil
+}
+
 func MockCloudSetup(platform string, data map[string]string, systemnamespace string) cloud.CloudProvider {
 	return &cloudImpl
 }


### PR DESCRIPTION
Since MPC assumes a cloud provider's capacity is limitless, it will create a virtual machine (VM) on the cloud provider and if the cloud provider cannot start the VM due to a lack of capacity (which is indicated by the VM being in a failed state), the user's build will fail. This commit checks if an IBM VM has entered a failed state and re-queues it after 1 minute if it has.