### PR TITLE
Fix conditional panic in MPC

### DIFF
--- a/pkg/ibm/ibmz.go
+++ b/pkg/ibm/ibmz.go
@@ -244,7 +244,7 @@ func (ibmz IBMZDynamicConfig) TerminateInstance(kubeClient client.Client, ctx co
 			if err != nil {
 				// Log an error if it's the first iteration or there is a non-404 code response
 				if repeats == 0 || (resp != nil && resp.StatusCode != http.StatusNotFound) {
-					log.Error(err, "failed to delete System Z instance; unable to get instance", "instanceId", *instance.ID)
+					log.Error(err, "failed to delete System Z instance; unable to get instance", "instanceId", instanceId)
 				}
 				return
 			}


### PR DESCRIPTION
When an instance cannot be retrieved while being deleted, the following panic occurs:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x1df841a]
goroutine 1013 [running]:
github.com/konflux-ci/multi-platform-controller/pkg/ibm.IBMZDynamicConfig.TerminateInstance.func1()
/opt/app-root/src/pkg/ibm/ibmz.go:454 +0x3ba
created by github.com/konflux-ci/multi-platform-controller/pkg/ibm.IBMZDynamicConfig.TerminateInstance in goroutine 135
/opt/app-root/src/pkg/ibm/ibmz.go:446 +0x1dd
````
This nil pointer is no longer referenced.