### PR TITLE
AWS EC2 Cloud Provider code cleanup (part 3)

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"context"
 	"encoding/base64"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -57,7 +56,7 @@ var _ = Describe("Ec2 Unit Test Suit", func() {
 				Expect(providerConfig.SecurityGroup).To(Equal("test-security-group"))
 				Expect(providerConfig.SecurityGroupId).To(Equal("test-security-group-id"))
 				Expect(providerConfig.SubnetId).To(Equal("test-subnet-id"))
-				Expect(providerConfig.SpotInstancePrice).To(Equal("test-spot-price"))
+				Expect(providerConfig.MaxSpotInstancePrice).To(Equal("test-spot-price"))
 				Expect(providerConfig.InstanceProfileName).To(Equal("test-instance-profile-name"))
 				Expect(providerConfig.InstanceProfileArn).To(Equal("test-instance-profile-arn"))
 				Expect(providerConfig.Disk).To(Equal(int32(expectedDisk)))
@@ -94,15 +93,14 @@ var _ = Describe("Ec2 Unit Test Suit", func() {
 
 	// This test is only here to check AWS connectivity in a very primitive and quick way until KFLUXINFRA-1065
 	// work starts
-	Describe("Testing pingSSHIp", func() {
-		DescribeTable("Testing the ability to ping via SSH a remote AWS ec2 instance",
+	Describe("Testing pingIpAddress", func() {
+		DescribeTable("Testing the ability to ping a remote AWS ec2 instance via SSH",
 			func(testInstanceIP string, shouldFail bool) {
 
-				ec2IPAddress, err := pingSSHIp(context.TODO(), testInstanceIP)
+				err := pingIPAddress(testInstanceIP)
 
 				if !shouldFail {
 					Expect(err).Should(BeNil())
-					Expect(testInstanceIP).Should(Equal(ec2IPAddress))
 				} else {
 					Expect(err).Should(HaveOccurred())
 				}

--- a/pkg/aws/ec2_helpers.go
+++ b/pkg/aws/ec2_helpers.go
@@ -7,35 +7,135 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/go-logr/logr"
+	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
 	v1 "k8s.io/api/core/v1"
 	types2 "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// checkInstanceConnectivity returns instance's IP address if it can be resolved.
-func (r AwsEc2DynamicConfig) checkInstanceConnectivity(ctx context.Context, instance *types.Instance) (string, error) {
-	if instance.PublicDnsName != nil && *instance.PublicDnsName != "" {
-		return pingSSHIp(ctx, *instance.PublicDnsName)
-	} else if instance.PrivateIpAddress != nil && *instance.PrivateIpAddress != "" {
-		return pingSSHIp(ctx, *instance.PrivateIpAddress)
-	}
-	return "", nil
-}
-
-// pingSSHIp returns the provided IP address if it can be resolved.
-func pingSSHIp(ctx context.Context, ipAddress string) (string, error) {
+// pingIPAddress tries to resolve the IP address ip. An error is returned if ipAddress couldn't be reached.
+func pingIPAddress(ipAddress string) error {
 	server, _ := net.ResolveTCPAddr("tcp", ipAddress+":22")
 	conn, err := net.DialTCP("tcp", nil, server)
 	if err != nil {
-		log := logr.FromContextOrDiscard(ctx)
-		log.Error(err, "failed to connect to AWS instance")
-		return "", err
+		return err
 	}
 	defer conn.Close()
 
-	return ipAddress, nil
+	return nil
+}
+
+// validateIPAddress returns the IP address of the EC2 instance ec after determining that the address
+// can be resolved (if the instance has one).
+func (ec AwsEc2DynamicConfig) validateIPAddress(ctx context.Context, instance *types.Instance) (string, error) {
+	var ip string
+	var err error
+	if instance.PublicDnsName != nil && *instance.PublicDnsName != "" {
+		ip = *instance.PublicDnsName
+	} else if instance.PrivateIpAddress != nil && *instance.PrivateIpAddress != "" {
+		ip = *instance.PrivateIpAddress
+	}
+
+	if ip != "" {
+		err = pingIPAddress(ip)
+	}
+	if err != nil {
+		log := logr.FromContextOrDiscard(ctx)
+		log.Error(err, "failed to connect to AWS instance")
+		err = fmt.Errorf("failed to resolve IP address %s: %w", ip, err)
+	}
+	return ip, err
+}
+
+// createClient uses AWS credentials and an EC2 configuration to create and return an EC2 client.
+func (ec AwsEc2DynamicConfig) createClient(kubeClient client.Client, ctx context.Context) (*ec2.Client, error) {
+	secretCredentials := SecretCredentialsProvider{Name: ec.Secret, Namespace: ec.SystemNamespace, Client: kubeClient}
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithCredentialsProvider(secretCredentials),
+		config.WithRegion(ec.Region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create an AWS config for an EC2 client: %w", err)
+	}
+	return ec2.NewFromConfig(cfg), nil
+}
+
+func (ec AwsEc2DynamicConfig) configureInstance(name string, instanceTag string, additionalInstanceTags map[string]string) *ec2.RunInstancesInput {
+	var subnet *string
+	var securityGroups []string
+	var securityGroupIds []string
+	var instanceProfile *types.IamInstanceProfileSpecification
+	var instanceMarketOpts *types.InstanceMarketOptionsRequest
+
+	if ec.SubnetId != "" {
+		subnet = aws.String(ec.SubnetId)
+	}
+	if ec.SecurityGroup != "" {
+		securityGroups = []string{ec.SecurityGroup}
+	}
+	if ec.SecurityGroupId != "" {
+		securityGroupIds = []string{ec.SecurityGroupId}
+	}
+	if ec.InstanceProfileName != "" || ec.InstanceProfileArn != "" {
+		instanceProfile = &types.IamInstanceProfileSpecification{}
+		if ec.InstanceProfileName != "" {
+			instanceProfile.Name = aws.String(ec.InstanceProfileName)
+		}
+		if ec.InstanceProfileArn != "" {
+			instanceProfile.Arn = aws.String(ec.InstanceProfileArn)
+		}
+	}
+
+	if ec.MaxSpotInstancePrice != "" {
+		instanceMarketOpts = &types.InstanceMarketOptionsRequest{
+			MarketType: types.MarketTypeSpot,
+			SpotOptions: &types.SpotMarketOptions{
+				MaxPrice:                     aws.String(ec.MaxSpotInstancePrice),
+				InstanceInterruptionBehavior: types.InstanceInterruptionBehaviorTerminate,
+				SpotInstanceType:             types.SpotInstanceTypeOneTime,
+			},
+		}
+	}
+
+	instanceTags := []types.Tag{
+		{Key: aws.String(MultiPlatformManaged), Value: aws.String("true")},
+		{Key: aws.String(cloud.InstanceTag), Value: aws.String(instanceTag)},
+		{Key: aws.String("Name"), Value: aws.String("multi-platform-builder-" + name)},
+	}
+	for k, v := range additionalInstanceTags {
+		instanceTags = append(instanceTags, types.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+
+	return &ec2.RunInstancesInput{
+		KeyName:            aws.String(ec.KeyName),
+		ImageId:            aws.String(ec.Ami), //ARM RHEL
+		InstanceType:       types.InstanceType(ec.InstanceType),
+		MinCount:           aws.Int32(1),
+		MaxCount:           aws.Int32(1),
+		EbsOptimized:       aws.Bool(true),
+		SecurityGroups:     securityGroups,
+		SecurityGroupIds:   securityGroupIds,
+		IamInstanceProfile: instanceProfile,
+		SubnetId:           subnet,
+		UserData:           ec.UserData,
+		BlockDeviceMappings: []types.BlockDeviceMapping{{
+			DeviceName:  aws.String("/dev/sda1"),
+			VirtualName: aws.String("ephemeral0"),
+			Ebs: &types.EbsBlockDevice{
+				DeleteOnTermination: aws.Bool(true),
+				VolumeSize:          aws.Int32(ec.Disk),
+				VolumeType:          types.VolumeTypeGp3,
+				Iops:                ec.Iops,
+				Throughput:          ec.Throughput,
+			},
+		}},
+		InstanceInitiatedShutdownBehavior: types.ShutdownBehaviorTerminate,
+		InstanceMarketOptions:             instanceMarketOpts,
+		TagSpecifications:                 []types.TagSpecification{{ResourceType: types.ResourceTypeInstance, Tags: instanceTags}},
+	}
 }
 
 // A SecretCredentialsProvider is a collection of information needed to generate
@@ -52,7 +152,7 @@ type SecretCredentialsProvider struct {
 	Client client.Client
 }
 
-// Retrieve is one of the AWS CredntialsProvider interface's methods that uses external Kubernetes
+// Retrieve is one of the AWS CredentialsProvider interface's methods that uses external Kubernetes
 // secrets or local environment variables to generate AWS credentials.
 func (r SecretCredentialsProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	// Use local environment variables for credentials


### PR DESCRIPTION
* Variables in the helper file were renamed for clarity
* Error messages in the helper file were prefaced with detail
* The function to launch an instance was broken up
* A function to create an EC2 client was created to reduce duplicated code