### PR TITLE
Add functionality to re-queue failed AWS EC2s

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -7,7 +7,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const InstanceTag = "multi-platform-instance"
+const (
+	InstanceTag = "multi-platform-instance"
+	OKState     = VMState("OK")
+	FailedState = VMState("FAILED")
+)
 
 type CloudProvider interface {
 	LaunchInstance(kubeClient client.Client, ctx context.Context, name string, instanceTag string, additionalInstanceTags map[string]string) (InstanceIdentifier, error)
@@ -16,7 +20,7 @@ type CloudProvider interface {
 	GetInstanceAddress(kubeClient client.Client, ctx context.Context, instanceId InstanceIdentifier) (string, error)
 	CountInstances(kubeClient client.Client, ctx context.Context, instanceTag string) (int, error)
 	ListInstances(kubeClient client.Client, ctx context.Context, instanceTag string) ([]CloudVMInstance, error)
-	GetState(kubeClient client.Client, ctx context.Context, instanceId InstanceIdentifier) (string, error)
+	GetState(kubeClient client.Client, ctx context.Context, instanceId InstanceIdentifier) (VMState, error)
 	SshUser() string
 }
 
@@ -27,3 +31,4 @@ type CloudVMInstance struct {
 }
 
 type InstanceIdentifier string
+type VMState string

--- a/pkg/ibm/ibmp.go
+++ b/pkg/ibm/ibmp.go
@@ -232,15 +232,15 @@ func (pw IBMPowerDynamicConfig) TerminateInstance(kubeClient client.Client, ctx 
 	return nil
 }
 
-// GetState returns ibmp's VM state from the IBM Power Systems Virtual Server service.
+// GetState returns instanceID's VM state from the pw cloud on the IBM Power Systems Virtual Server service.
 // See https://cloud.ibm.com/apidocs/power-cloud#pcloud-pvminstances-get for more information.
-func (ibmp IBMPowerDynamicConfig) GetState(kubeClient client.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
-	service, err := ibmp.createAuthenticatedBaseService(ctx, kubeClient)
+func (pw IBMPowerDynamicConfig) GetState(kubeClient client.Client, ctx context.Context, instanceID cloud.InstanceIdentifier) (cloud.VMState, error) {
+	service, err := pw.createAuthenticatedBaseService(ctx, kubeClient)
 	if err != nil {
 		return "", fmt.Errorf("failed to create an authenticated base service: %w", err)
 	}
 
-	instance, err := ibmp.getInstance(ctx, service, string(instanceId))
+	instance, err := pw.getInstance(ctx, service, string(instanceID))
 	// Probably still waiting for the instance to come up
 	if err != nil {
 		return "", nil
@@ -248,9 +248,9 @@ func (ibmp IBMPowerDynamicConfig) GetState(kubeClient client.Client, ctx context
 
 	// An instance in a failed state has a status of "ERROR" and a health of "CRITICAL"
 	if *instance.Status == "ERROR" && instance.Health.Status == "CRITICAL" {
-		return "FAILED", nil
+		return cloud.FailedState, nil
 	}
-	return "OK", nil
+	return cloud.OKState, nil
 }
 
 func (pw IBMPowerDynamicConfig) SshUser() string {

--- a/pkg/reconciler/taskrun/dynamic.go
+++ b/pkg/reconciler/taskrun/dynamic.go
@@ -134,7 +134,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 					"instanceId", cloud.InstanceIdentifier(tr.Annotations[CloudInstanceId]),
 				)
 				requeueTime = time.Second * 10
-			} else if state == "FAILED" { //VM is in a failed state; try to delete the instance and unassign it from the TaskRun
+			} else if state == cloud.FailedState { //VM is in a failed state; try to delete the instance and unassign it from the TaskRun
 				log.Info("VM instance is in a failed state; will attempt to terminate, unassign from task")
 				terr := r.CloudProvider.TerminateInstance(taskRun.client, ctx, cloud.InstanceIdentifier(tr.Annotations[CloudInstanceId]))
 				if terr != nil {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -890,8 +890,8 @@ func (m *MockCloud) GetInstanceAddress(kubeClient runtimeclient.Client, ctx cont
 }
 
 // TODO: implement
-func (m *MockCloud) GetState(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
-	return "ACTIVE", nil
+func (m *MockCloud) GetState(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (cloud.VMState, error) {
+	return cloud.OKState, nil
 }
 
 func MockCloudSetup(platform string, data map[string]string, systemnamespace string) cloud.CloudProvider {


### PR DESCRIPTION
Since MPC assumes a cloud provider's capacity is limitless, it will
create a virtual machine (VM) on the cloud provider and if the cloud
provider cannot start the VM due to a lack of capacity (which is
indicated by the VM being in a failed state), the user's build will fail.
This commit implements the cloud interface function necessary to
enter a re-queue process committed in PR https://github.com/konflux-ci/multi-platform-controller/pull/425.