### PR TITLE
KFLUXINFRA-1073 + KFLUXINFRA-1440 completion part II

### DIFF
--- a/.github/workflows/mpc-test-sealights.yaml
+++ b/.github/workflows/mpc-test-sealights.yaml
@@ -43,6 +43,11 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: "./go.mod"
+      - name: Install ginkgo
+        run: |
+            echo "[MPC] installing Ginkgo"
+            go get github.com/onsi/ginkgo/v2@v2.22.2
+            go install github.com/onsi/ginkgo/v2/ginkgo
       - name: Download SeaLights Go agent and CLI tool
         run: |
           echo "[Sealights] Downloading Sealights Golang & CLI Agents..."


### PR DESCRIPTION
Continuing to make changes for switching fully to ginkgo and adding the missing test one step at a time.
Step 2: Adding the missing test that was not converted from the original taskrun_test.go - TestChangeHostConfig.