### PR TITLE
Make concurrent reconciliations configurable

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/konflux-ci/multi-platform-controller/pkg/controller"
+	k8scontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	//+kubebuilder:scaffold:imports
 	"github.com/go-logr/logr"
@@ -34,6 +35,7 @@ func main() {
 	var probeAddr string
 	var abAPIExportName string
 	var secureMetrics bool
+	var concurrentReconciles int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
@@ -43,6 +45,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&concurrentReconciles, "concurrent-reconciles", 10, "The concurrency level for reconciling resources.")
+
 	opts := zap.Options{
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 		ZapOpts:     []zap2.Option{zap2.WithCaller(true)},
@@ -61,7 +65,7 @@ func main() {
 
 	var mgr ctrl.Manager
 	var err error
-	mopts := ctrl.Options{
+	managerOptions := ctrl.Options{
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "5483be8f.redhat.com",
@@ -72,7 +76,11 @@ func main() {
 		},
 	}
 
-	mgr, err = controller.NewManager(restConfig, mopts)
+	controllerlOptions := k8scontroller.Options{
+		MaxConcurrentReconciles: concurrentReconciles,
+	}
+
+	mgr, err = controller.NewManager(restConfig, managerOptions, controllerlOptions)
 	if err != nil {
 		mainLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -76,11 +76,11 @@ func main() {
 		},
 	}
 
-	controllerlOptions := k8scontroller.Options{
+	controllerOptions := k8scontroller.Options{
 		MaxConcurrentReconciles: concurrentReconciles,
 	}
 
-	mgr, err = controller.NewManager(restConfig, managerOptions, controllerlOptions)
+	mgr, err = controller.NewManager(restConfig, managerOptions, controllerOptions)
 	if err != nil {
 		mainLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -31,7 +31,7 @@ var (
 
 const TaskRunLabel = "tekton.dev/taskRun"
 
-func NewManager(cfg *rest.Config, managerOptions ctrl.Options, controllerlOptions controller.Options) (ctrl.Manager, error) {
+func NewManager(cfg *rest.Config, managerOptions ctrl.Options, controllerOptions controller.Options) (ctrl.Manager, error) {
 	// do not check tekton in kcp
 	// we have seen in e2e testing that this path can get invoked prior to the TaskRun CRD getting generated,
 	// and controller-runtime does not retry on missing CRDs.
@@ -96,8 +96,8 @@ func NewManager(cfg *rest.Config, managerOptions ctrl.Options, controllerlOption
 		return nil, err
 	}
 	controllerLog.Info("deployed in namespace", "namespace", operatorNamespace)
-	controllerLog.Info("controller concurrency", "maxConcurrentReconciles", controllerlOptions.MaxConcurrentReconciles)
-	if err := taskrun.SetupNewReconcilerWithManager(mgr, operatorNamespace, controllerlOptions); err != nil {
+	controllerLog.Info("controller concurrency", "maxConcurrentReconciles", controllerOptions.MaxConcurrentReconciles)
+	if err := taskrun.SetupNewReconcilerWithManager(mgr, operatorNamespace, controllerOptions); err != nil {
 		return nil, err
 	}
 

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-func SetupNewReconcilerWithManager(mgr ctrl.Manager, operatorNamespace string, optiminons controller.Options) error {
+func SetupNewReconcilerWithManager(mgr ctrl.Manager, operatorNamespace string, options controller.Options) error {
 	r := newReconciler(mgr, operatorNamespace)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.TaskRun{}).

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-func SetupNewReconcilerWithManager(mgr ctrl.Manager, operatorNamespace string, options controller.Options) error {
+func SetupNewReconcilerWithManager(mgr ctrl.Manager, operatorNamespace string, optiminons controller.Options) error {
 	r := newReconciler(mgr, operatorNamespace)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.TaskRun{}).

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -6,10 +6,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-func SetupNewReconcilerWithManager(mgr ctrl.Manager, operatorNamespace string) error {
+func SetupNewReconcilerWithManager(mgr ctrl.Manager, operatorNamespace string, options controller.Options) error {
 	r := newReconciler(mgr, operatorNamespace)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.TaskRun{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithOptions(options).
 		Complete(r)
 }


### PR DESCRIPTION
We have set 10 as an emergency action,  but now it turns that we're not always need that much (and even can be bad for some types of builds)