### PR TITLE
ci: upload cover.out to codecov

### DIFF
--- a/.github/workflows/mpc-test-sealights.yaml
+++ b/.github/workflows/mpc-test-sealights.yaml
@@ -93,6 +93,8 @@ jobs:
         run: make test
       - name: Codecov
         uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4
+        with:
+          files: ./cover.out
       - name: clean all SeaLights secret stuff
         run: |
           echo "[Sealights] Cleaning up after SeaLights run"


### PR DESCRIPTION
Codecov is currently not doing much since we're not telling it where to find coverage data.  Since we're generating it, might as well use it.