### PR TITLE
Fix host pool update tests

### DIFF
--- a/pkg/aws/ec2_helpers_test.go
+++ b/pkg/aws/ec2_helpers_test.go
@@ -173,7 +173,7 @@ var _ = Describe("AWS EC2 Helper Functions", func() {
 				}
 
 			},
-			Entry("Positive test - IP address", "150.239.19.36", false),
+			Entry("Positive test - IP address", "127.0.0.1", false),
 			Entry("Negative test - no such IP address", "192.168.4.231", true),
 			Entry("Negative test - no such DNS name", "not a DNS name, that's for sure", true),
 			Entry("Negative test - not an IP address", "Not an IP address", true),

--- a/pkg/aws/ec2_helpers_test.go
+++ b/pkg/aws/ec2_helpers_test.go
@@ -173,7 +173,7 @@ var _ = Describe("AWS EC2 Helper Functions", func() {
 				}
 
 			},
-			Entry("Positive test - IP address", "127.0.0.1", false),
+			Entry("Positive test - IP address", "169.48.19.34", false),
 			Entry("Negative test - no such IP address", "192.168.4.231", true),
 			Entry("Negative test - no such DNS name", "not a DNS name, that's for sure", true),
 			Entry("Negative test - not an IP address", "Not an IP address", true),

--- a/pkg/reconciler/taskrun/hostupdate_test.go
+++ b/pkg/reconciler/taskrun/hostupdate_test.go
@@ -18,6 +18,10 @@
 package taskrun
 
 import (
+	"context"
+	"sync"
+	"time"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const testNamespace = "default"
@@ -92,110 +97,130 @@ var _ = Describe("HostUpdateTaskRunTest", func() {
 		}
 	})
 
-	DescribeTable("Creating taskruns for updating static hosts in a pool",
-		func(ctx SpecContext, hostConfigData map[string]string, hostSuffix string, shouldFail bool) {
+	It("should fail when the config doesn't exist", func(ctx SpecContext) {
+		// given: the host config configmap doesn't exist
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
 
-			hostConfig.Data = testConfigDataFromTestData(hostConfigData, hostSuffix)
+		// when: host pools are updated
+		log := logr.FromContextOrDiscard(ctx)
+		UpdateHostPools(testNamespace, k8sClient, &log)
 
-			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(hostConfig).Build()
-			log := logr.FromContextOrDiscard(ctx)
-			zeroTaskRuns := false
+		// then: no host pool update tasks are created
+		list := v1.TaskRunList{}
+		Expect(k8sClient.List(ctx, &list)).To(Succeed())
+		Expect(list.Items).To(BeEmpty())
+	})
 
-			// tested function call
-			UpdateHostPools(testNamespace, k8sClient, &log)
+	It("should succeed with a valid host config", func(ctx SpecContext) {
+		// We need a waitgroup to synchronize the spawned goroutine in
+		// UpdateHostPools with this thread.  Without this, our assertions may run
+		// before any taskruns get created, which will cause these tests to flake.
+		waitGroup := &sync.WaitGroup{}
 
-			// get list of all TaskRuns, as we cannot predict the name
-			createdList := v1.TaskRunList{}
-
-			// test everything in TaskRun creation that is not part of the table testing
-			Eventually(func(g Gomega) {
-				// TaskRun successfully created
-				g.Expect(k8sClient.List(ctx, &createdList, client.InNamespace(testNamespace))).To(Succeed())
-
-				// Only one TaskRun was created == hostConfigData was good data
-				zeroTaskRuns = len(createdList.Items) == 0
-				g.Expect(zeroTaskRuns).To(Equal(shouldFail))
-
-			}).Should(Succeed())
-
-			if !zeroTaskRuns {
-				// set label field filled correctly
-				Expect(createdList.Items[0].Labels).To(HaveKeyWithValue(TaskTypeLabel, TaskTypeUpdate))
-
-				// extract TaskRun data to begin testing individual fields were correctly filled
-				updatedHostData := hostDataFromTRSpec(createdList.Items[0])
-
-				// validate each field is exactly as it's expected to be
-				Expect(hostConfigData["address"]).To(Equal(updatedHostData["address"]))
-				Expect(hostConfigData["user"]).To(Equal(updatedHostData["user"]))
-				Expect(updatedHostData["secret"]).To(Equal(updatedHostData["secret"]))
-				Expect(hostConfigData["concurrency"]).To(Equal(updatedHostData["concurrency"]))
-				Expect(hostConfigData["platform"]).To(Equal(updatedHostData["platform"]))
-			}
-		},
-		Entry("Positive test", map[string]string{
+		// given: a valid host hostConfigData
+		hostConfigData := map[string]string{
 			"address":     "10.130.75.23",
 			"secret":      "internal-koko-hazamar-ssh-key",
 			"concurrency": "1",
 			"user":        "koko_hazamar",
-			"platform":    "linux/ppc64le"},
-			"host.koko-hazamar-prod-1.", false),
-		Entry("Negative test - empty data map", map[string]string{}, "", true),
-		Entry("Negative test - dynamic host keys", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "internal-moshe-kipod-ssh-key",
-			"concurrency": "1",
-			"user":        "koko_hazamar",
-			"platform":    "linux/ppc64le"},
-			"dynamic.moshe-kipod-prod-1.", true),
-		Entry("Negative test - bad key format", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "internal-prod-ibm-ssh-key",
-			"concurrency": "1",
-			"user":        "root",
-			"platform":    "linux/ppc64le"},
-			"host.", true),
-		Entry("Negative test - bad address field", map[string]string{
-			"address":     "10.130",
-			"secret":      "internal-prod-ibm-ssh-key",
-			"concurrency": "1",
-			"user":        "koko_hazamar",
-			"platform":    "linux/ppc64le"},
-			"host.koko-hazamar-prod-1.", true),
-		Entry("Negative test - bad secret field", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "",
-			"concurrency": "1",
-			"user":        "koko_hazamar",
-			"platform":    "linux/ppc64le"},
-			"host.koko-hazamar-prod-1.", true),
-		Entry("Negative test - bad concurrency part I", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "internal-prod-ibm-ssh-key",
-			"concurrency": "-1",
-			"user":        "koko_hazamar",
-			"platform":    "linux/ppc64le"},
-			"host.koko-hazamar-prod-1.", true),
-		Entry("Negative test - bad concurrency part II", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "internal-prod-ibm-ssh-key",
-			"concurrency": "1234567890",
-			"user":        "koko_hazamar",
-			"platform":    "linux/ppc64le"},
-			"host.koko-hazamar-prod-1.", true),
-		Entry("Negative test - bad user", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "internal-prod-ibm-ssh-key",
-			"concurrency": "1",
-			"user":        "root",
-			"platform":    "linux/ppc64le"},
-			"host.koko-hazamar-prod-1.", true),
-		Entry("Negative test - bad platform", map[string]string{
-			"address":     "10.130.75.23",
-			"secret":      "internal-prod-ibm-ssh-key",
-			"concurrency": "1",
-			"user":        "koko_hazamar",
-			"platform":    "linux/moshe_kipod555"},
-			"host.koko-hazamar-prod-1.", true),
-	)
+			"platform":    "linux/ppc64le",
+		}
+		hostConfig.Data = testConfigDataFromTestData(hostConfigData, "host.koko-hazamar-prod-1.")
+
+		// We expect one creation request, so increment the wait counter by one.
+		waitGroup.Add(1)
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(hostConfig).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Create: func(
+					ctx context.Context,
+					client client.WithWatch,
+					obj client.Object,
+					opts ...client.CreateOption,
+				) error {
+					err := client.Create(ctx, obj, opts...)
+					waitGroup.Done()
+					return err
+				},
+			}).
+			Build()
+
+		// when: host pools are updated
+		log := logr.FromContextOrDiscard(ctx)
+		UpdateHostPools(testNamespace, k8sClient, &log)
+
+		// when: spawned threads run to completion
+		waitGroup.Wait()
+
+		// get list of all TaskRuns, as we cannot predict the name
+		createdList := v1.TaskRunList{}
+
+		// then: host pool update task runs are created
+		Expect(k8sClient.List(ctx, &createdList, client.InNamespace(testNamespace))).To(Succeed())
+		Expect(createdList.Items).To(HaveLen(1))
+
+		// set label field filled correctly
+		Expect(createdList.Items[0].Labels).To(HaveKeyWithValue(TaskTypeLabel, TaskTypeUpdate))
+
+		// extract TaskRun data to begin testing individual fields were correctly filled
+		updatedHostData := hostDataFromTRSpec(createdList.Items[0])
+
+		// then: the updated host data should be equivalent to what we provided
+		Expect(hostConfigData).To(BeEquivalentTo(updatedHostData))
+	})
+
+	When("Host config is invalid", func() {
+		DescribeTable("Updating host pools should not spawn taskruns",
+			func(ctx SpecContext, hostConfigData map[string]string, hostSuffix string) {
+				// In these tests, we have no way of synchronizing any spawned goroutines
+				// with this thread, since we do no expect any to be spawned.  Instead, we
+				// will expect the calls to list all taskruns to succeed multiple times with
+				// some delays between checks. This is not an ideal check, but it works in
+				// practice.  Having these checks helps prevent buggy tests and buggy
+				// implementations of UpdateHostPools.
+
+				// given: an invalid host config
+				hostConfig.Data = testConfigDataFromTestData(hostConfigData, hostSuffix)
+
+				k8sClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithRuntimeObjects(hostConfig).
+					Build()
+
+				// when: host pools are updated
+				log := logr.FromContextOrDiscard(ctx)
+				UpdateHostPools(testNamespace, k8sClient, &log)
+
+				// test everything in TaskRun creation that is not part of the table testing
+				Eventually(func(g Gomega) {
+					createdList := v1.TaskRunList{}
+					g.Expect(k8sClient.List(ctx, &createdList, client.InNamespace(testNamespace))).To(Succeed())
+					g.Expect(createdList.Items).To(BeEmpty())
+				}).
+					MustPassRepeatedly(3).
+					ProbeEvery(time.Second).
+					Within(10 * time.Second).
+					Should(Succeed())
+			},
+			Entry("empty data map", map[string]string{}, ""),
+			Entry("dynamic host keys", map[string]string{
+				"address":     "10.130.75.23",
+				"secret":      "internal-moshe-kipod-ssh-key",
+				"concurrency": "1",
+				"user":        "koko_hazamar",
+				"platform":    "linux/ppc64le"},
+				"dynamic.moshe-kipod-prod-1."),
+			Entry("bad key format", map[string]string{
+				"address":     "10.130.75.23",
+				"secret":      "internal-prod-ibm-ssh-key",
+				"concurrency": "1",
+				"user":        "root",
+				"platform":    "linux/ppc64le"},
+				"host."),
+		)
+	})
 })


### PR DESCRIPTION
Our host pool tests aren't testing what we think they're testing, so we could stand to improve them a bit.  The highlights:

- Assert that secrets are what we expect them to be, not that they're shaped like itself.
- Remove some tests that are actually race conditions in disguise (and fix the test to ideally not run into the race condition).
- Add a test to exercise another path through `UpdateHostPools`, so we should have more coverage.