### PR TITLE
Remove codecov

### DIFF
--- a/.github/workflows/mpc-test-sealights.yaml
+++ b/.github/workflows/mpc-test-sealights.yaml
@@ -91,8 +91,6 @@ jobs:
         run: make build
       - name: Test
         run: make test
-      - name: Codecov
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4
       - name: clean all SeaLights secret stuff
         run: |
           echo "[Sealights] Cleaning up after SeaLights run"


### PR DESCRIPTION
Codecov is doing redundant work for us, since we already do coverage tracking through sealights.  Considering it's been broken for a while, let's just remove it.

Supercedes #456.