### PR TITLE
Minor change found during KFLUXINFRA-957

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -91,28 +91,6 @@ var _ = Describe("Ec2 Unit Test Suit", func() {
 		)
 	})
 
-	// This test is only here to check AWS connectivity in a very primitive and quick way until KFLUXINFRA-1065
-	// work starts
-	Describe("Testing pingIpAddress", func() {
-		DescribeTable("Testing the ability to ping a remote AWS ec2 instance via SSH",
-			func(testInstanceIP string, shouldFail bool) {
-
-				err := pingIPAddress(testInstanceIP)
-
-				if !shouldFail {
-					Expect(err).Should(BeNil())
-				} else {
-					Expect(err).Should(HaveOccurred())
-				}
-
-			},
-			Entry("Positive test - IP address", "150.239.19.36", false),
-			Entry("Negative test - no such IP address", "192.168.4.231", true),
-			Entry("Negative test - no such DNS name", "not a DNS name, that's for sure", true),
-			Entry("Negative test - not an IP address", "Not an IP address", true),
-		)
-	})
-
 	Describe("Testing SshUser", func() {
 		It("The simplest damn test", func() {
 			var awsTestInstance AWSEc2DynamicConfig

--- a/pkg/aws/ec2_helpers_test.go
+++ b/pkg/aws/ec2_helpers_test.go
@@ -153,4 +153,27 @@ var _ = Describe("AWS EC2 Helper Functions", func() {
 			map[string][]string{"test-namespace": {"task1", "task2", "task3", "task4"}},
 			[]string{"task1", "task2", "task3", "task4"}),
 	)
+
+	// This test is only here to check AWS connectivity in a very primitive and quick way until KFLUXINFRA-1065
+	// work starts
+	Describe("Testing pingIpAddress", func() {
+		DescribeTable("Testing the ability to ping a remote AWS ec2 instance via SSH",
+			func(testInstanceIP string, shouldFail bool) {
+
+				err := pingIPAddress(testInstanceIP)
+
+				if !shouldFail {
+					Expect(err).Should(BeNil())
+				} else {
+					Expect(err).Should(HaveOccurred())
+				}
+
+			},
+			Entry("Positive test - IP address", "150.239.19.36", false),
+			Entry("Negative test - no such IP address", "192.168.4.231", true),
+			Entry("Negative test - no such DNS name", "not a DNS name, that's for sure", true),
+			Entry("Negative test - not an IP address", "Not an IP address", true),
+		)
+	})
+
 })


### PR DESCRIPTION
Housecleaning - found that the test for pingIPAddress is in the test file for testing ec2.go, while pingIPAddress has been moved to ec2_helpers.go, so its test should be moved to ec2_helpers_test.go.