### PR TITLE
tests: fix ginkgo test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ manifests: controller-gen
 
 .PHONY: test
 test: fmt vet ## Run tests.
-	ginkgo --race -p --github-output --json-report=test-report.json -v ././cmd/... ././pkg/... -coverprofile cover.out -covermode atomic
+	ginkgo --race -p --github-output -coverprofile cover.out -covermode atomic --json-report=test-report.json -v ././cmd/... ././pkg/...
 
 .PHONY: build
 build: fmt vet clean manifests


### PR DESCRIPTION
Newer versions (> v2.23 as far as I can tell) of ginkgo expect all command-line arguments before packages.  Fix invocations of ginkgo to abide by these rules.