### PR TITLE
Autogenerated names for provision and cleanup tasks

### DIFF
--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -3,6 +3,7 @@ package taskrun
 import (
 	"context"
 	"fmt"
+	"knative.dev/pkg/kmeta"
 	"strings"
 	"time"
 
@@ -134,7 +135,7 @@ func (hp HostPool) Deallocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.T
 		//kick off the clean task
 		//kick off the provisioning task
 		provision := v1.TaskRun{}
-		provision.Name = "cleanup-" + tr.Name
+		provision.Name = kmeta.ChildName(tr.Name, "cleanup")
 		provision.Namespace = r.operatorNamespace
 		provision.Labels = labelMap
 		provision.Annotations = map[string]string{TaskTargetPlatformAnnotation: hp.targetPlatform}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -3,6 +3,7 @@ package taskrun
 import (
 	"context"
 	"fmt"
+	"knative.dev/pkg/kmeta"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -816,7 +817,7 @@ func launchProvisioningTask(r *ReconcileTaskRun, ctx context.Context, tr *tekton
 	}
 
 	provision := tektonapi.TaskRun{}
-	provision.Name = "provision-" + tr.Name
+	provision.Name = kmeta.ChildName(tr.Name, "provision")
 	provision.Namespace = r.operatorNamespace
 	provision.Labels = map[string]string{TaskTypeLabel: TaskTypeProvision, UserTaskNamespace: tr.Namespace, UserTaskName: tr.Name, AssignedHost: tr.Labels[AssignedHost]}
 	provision.Annotations = map[string]string{TaskTargetPlatformAnnotation: platformLabel(platform)}


### PR DESCRIPTION
We want names of provision and cleanup tasks to be inherited from priginal TR name, 
but initial implementation can exceed the allowe names length.

This one is using the common method for names generation, which is used for all pipeline API resources like PLR TR etc.