### PR TITLE
KFLUXINFRA-1591- unit test and code fixes for ibmp_helpers.go-> parseCRN

### DIFF
--- a/pkg/ibm/ibmp_helpers.go
+++ b/pkg/ibm/ibmp_helpers.go
@@ -105,18 +105,36 @@ func (pw IBMPowerDynamicConfig) listInstances(ctx context.Context, service *core
 // See the [IBM CRN docs](https://cloud.ibm.com/docs/account?topic=account-crn#service-instance-crn)
 // for more information on CRN formatting.
 func (pw IBMPowerDynamicConfig) parseCRN() (string, error) {
-	locationIndex := 5
-	serviceInstanceIndex := 7
+	if !strings.HasPrefix(pw.CRN, "crn:") {
+		return "", fmt.Errorf("invalid CRN: must start with 'crn:'")
+	}
+
 	crnSegments := strings.Split(pw.CRN, ":")
 
+	// To prevent index-out-of-bounds panic if this string gets truncated, we need to verify the correct length - 10.
+	//Like the commandments.
+	if len(crnSegments) != 10 {
+		return "", fmt.Errorf("invalid CRN format: expected 10 segments, but got %d", len(crnSegments))
+	}
+
+	const (
+		serviceNameIndex     = 4
+		locationIndex        = 5
+		serviceInstanceIndex = 7
+	)
+
+	// Verify this is definitely a ppc - see:
+	// [IBM Cloud global catalog service](https://globalcatalog.cloud.ibm.com/search?noLocations=true&q=power-iaas)
+	if crnSegments[serviceNameIndex] != "power-iaas" {
+		return "", fmt.Errorf("invalid CRN service name: expected 'power-iaas', but got '%s'", crnSegments[serviceNameIndex])
+	}
+
 	if crnSegments[locationIndex] == "global" {
-		errMsg := "this resource is global and has no service instance"
-		return "", errors.New(errMsg)
+		return "", errors.New("this resource is global and has no service instance")
 	}
 	serviceInstance := crnSegments[serviceInstanceIndex]
 	if serviceInstance == "" {
-		errMsg := "the service instance is null"
-		return "", errors.New(errMsg)
+		return "", errors.New("the service instance is null")
 	}
 
 	return serviceInstance, nil

--- a/pkg/ibm/ibmp_helpers_test.go
+++ b/pkg/ibm/ibmp_helpers_test.go
@@ -120,4 +120,73 @@ var _ = Describe("IBM Power Cloud Helper Functions", func() {
 			)
 		})
 	})
+
+	// A unit test for parseCRN. Tests the logic of fetching the service instance string from a IBMPowerDynamicConfig as
+	// well as the logic of all the data validation on CRN in IBMPowerDynamicConfig .
+	// Does this by three basic methods:
+	// 1. Verifying a service instance is extracted properly from a valid CRN
+	// 2. Verifying all the data validation rules are triggered by input it's designed to fail. Also validates proper
+	//    error messages are returned.
+	// 3. Verifies edge cases of extremely flawed CRN do not
+	Describe("parseCRN helper function tests", func() {
+		var (
+			powerConfig IBMPowerDynamicConfig
+			validCRN    = "crn:v1:bluemix:public:power-iaas:dal10:a/123456789:service-guid-1234::"
+		)
+
+		When("given a valid and well-formed CRN", func() {
+			It("should correctly extract the service instance ID without error", func() {
+				powerConfig = IBMPowerDynamicConfig{CRN: validCRN}
+				serviceInstance, err := powerConfig.parseCRN()
+
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(serviceInstance).Should(Equal("service-guid-1234"))
+			})
+		})
+
+		When("given a malformed or invalid CRN", func() {
+			DescribeTable("it should return a descriptive error",
+				func(crn string, expectedErrorSubstring string) {
+					powerConfig = IBMPowerDynamicConfig{CRN: crn}
+					_, err := powerConfig.parseCRN()
+
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring(expectedErrorSubstring))
+				},
+				Entry("when the CRN is missing the 'crn:' prefix",
+					"moshe-kipod:v1:bluemix:public:power-iaas:dal10:a/123:service-guid::",
+					"must start with 'crn:'"),
+				Entry("when the CRN has too few segments",
+					"crn:v1:bluemix:public:power-iaas:dal10:a/123:service-guid:",
+					"expected 10 segments, but got 9"),
+				Entry("when the CRN has too many segments",
+					"crn:v1:bluemix:public:power-iaas:dal10:a/123:service-guid:::moshe-kipod",
+					"expected 10 segments, but got 11"),
+				Entry("when the service name is not 'power-iaas'",
+					"crn:v1:bluemix:public:moshe-kipod-service:dal10:a/123:service-guid::",
+					"invalid CRN service name"),
+				Entry("when the resource is global",
+					"crn:v1:bluemix:public:power-iaas:global:a/123:service-guid::",
+					"this resource is global"),
+				Entry("when the service instance is null",
+					"crn:v1:bluemix:public:power-iaas:dal10:a/123:::",
+					"the service instance is null"),
+			)
+		})
+
+		When("given an edge-case CRN", func() {
+			DescribeTable("it should fail gracefully",
+				func(crn string, expectedErrorSubstring string) {
+					powerConfig = IBMPowerDynamicConfig{CRN: crn}
+					_, err := powerConfig.parseCRN()
+
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring(expectedErrorSubstring))
+				},
+				Entry("when the CRN is an empty string", "", "must start with 'crn:'"),
+				Entry("when the CRN is just the prefix", "crn:", "expected 10 segments, but got 2"),
+				Entry("when the CRN is just colons", ":::::::::", "must start with 'crn:'"),
+			)
+		})
+	})
 })


### PR DESCRIPTION
In this PR are two changes:

1. Code changes to parseCRN, which include:
2. Fix a bug that placed parseCRN in danger of an uncaught panic in case the CRN string has been truncated and has less than 7 segments when split on colons. Also added more data validation to match the attributes in a CRN string that match a ppc machine