### PR TITLE
Fixup apply-tags task params to conform newest version

### DIFF
--- a/.tekton/multi-platform-controller-otp-service-pull-request.yaml
+++ b/.tekton/multi-platform-controller-otp-service-pull-request.yaml
@@ -539,6 +539,8 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_URL
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST

--- a/.tekton/multi-platform-controller-otp-service-pull-request.yaml
+++ b/.tekton/multi-platform-controller-otp-service-pull-request.yaml
@@ -539,12 +539,12 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-        - name: IMAGE
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-otp-service-pull-request.yaml
+++ b/.tekton/multi-platform-controller-otp-service-pull-request.yaml
@@ -539,8 +539,10 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-otp-service-push.yaml
+++ b/.tekton/multi-platform-controller-otp-service-push.yaml
@@ -536,8 +536,10 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-      - name: IMAGE
+      - name: IMAGE_URL
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-otp-service-push.yaml
+++ b/.tekton/multi-platform-controller-otp-service-push.yaml
@@ -536,6 +536,8 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_URL
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/multi-platform-controller-pull-request.yaml
+++ b/.tekton/multi-platform-controller-pull-request.yaml
@@ -539,6 +539,8 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_URL
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST

--- a/.tekton/multi-platform-controller-pull-request.yaml
+++ b/.tekton/multi-platform-controller-pull-request.yaml
@@ -539,12 +539,12 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-        - name: IMAGE
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-pull-request.yaml
+++ b/.tekton/multi-platform-controller-pull-request.yaml
@@ -539,8 +539,10 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-push.yaml
+++ b/.tekton/multi-platform-controller-push.yaml
@@ -536,12 +536,12 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-        - name: IMAGE
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: IMAGE_URL
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-        - name: IMAGE_DIGEST
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-push.yaml
+++ b/.tekton/multi-platform-controller-push.yaml
@@ -536,8 +536,10 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_URL
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/multi-platform-controller-push.yaml
+++ b/.tekton/multi-platform-controller-push.yaml
@@ -536,6 +536,8 @@ spec:
         workspace: workspace
     - name: apply-tags
       params:
+        - name: IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_URL
           value: $(tasks.build-image-index.results.IMAGE_URL)
         - name: IMAGE_DIGEST


### PR DESCRIPTION
To be able to apply latest task references, we need to update the params.