### PR TITLE
KFLUXINFRA-1593: unit tests for common.go functions and backend_probe.go -> CheckAvailability

### DIFF
--- a/pkg/metrics/backend_probe_test.go
+++ b/pkg/metrics/backend_probe_test.go
@@ -1,0 +1,130 @@
+package mpcmetrics
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// This test suite covers the only testable function in backend_probe.go - CheckAvailability.
+// Is split into two main sections:
+//  1. Testing the logic of returning nothing (successful platform) or returning an error (failing platform). This is
+//     not only tested by creating conditions for a successful/failing platform, but also a boundary test for the
+//     errorThreshold constant that dynamically evaluates the boundaries to test for future robustness.
+//  2. Test the state change of a platform as CheckAvailability is called twice, verifying the Swap() action clears all
+//     successes and failures of a probe.
+var _ = Describe("Backend_Probe CheckAvailability unit tests", func() {
+
+	var (
+		probe AvailabilityProbe
+		ctx   context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+	})
+
+	// Testing the logic determining whether a platform is successful or failing
+	When("the probe is healthy", func() {
+		It("should pass with no successes and no failures", func() {
+			probe = setupProbeWithCounts(0, 0)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should pass with no successes and only one failure", func() {
+			probe = setupProbeWithCounts(0, 1)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should pass with many successes and no failures", func() {
+			probe = setupProbeWithCounts(20, 0)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should pass with a failure rate clearly below the threshold", func() {
+			probe = setupProbeWithCounts(10, 1) // success/failures ratio - 0.1
+			err := probe.CheckAvailability(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	When("the probe is unhealthy", func() {
+		It("should fail with zero successes and multiple failures", func() {
+			probe = setupProbeWithCounts(0, 2)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("should fail with a failure rate clearly above the threshold", func() {
+			probe = setupProbeWithCounts(10, 9) // success/failures ratio - 0.9
+			err := probe.CheckAvailability(ctx)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	When("testing errorThreshold boundary conditions", func() {
+
+		baseSuccesses := 100
+		// A count of failures that should result in a ratio == errorThreshold
+		failuresAtEdge := int(float64(baseSuccesses) * errorThreshold)
+
+		// Below are calculations written with the assumption that errorThreshold will never be less than 0.1, because
+		// it's a less realistic situation in production. It also feels like a threshold that's way too accurate
+		// for the general coding spirit of the team - if it's so small, why not just make failures completely
+		// intolerable and be done with it.
+		failuresToPass := failuresAtEdge - 1 // A count of failures that should result in a ratio < errorThreshold
+		failuresToFail := failuresAtEdge + 1 // A count of failures that should result in a ratio > errorThreshold
+
+		It("should pass when the failure rate is just below the threshold", func() {
+			probe := setupProbeWithCounts(baseSuccesses, failuresToPass)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should pass when the failure rate is exactly at the threshold", func() {
+			probe := setupProbeWithCounts(baseSuccesses, failuresAtEdge)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should fail when the failure rate is just over the threshold", func() {
+			probe := setupProbeWithCounts(baseSuccesses, failuresToFail)
+			err := probe.CheckAvailability(ctx)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	// State change test
+	When("its state is checked sequentially", func() {
+		It("should reset its counters, resulting in a healthy status on the subsequent check", func() {
+			By("1. Setting up an unhealthy state")
+			probe = setupProbeWithCounts(0, 5)
+
+			By("2. Verifying the first check fails as expected")
+			err1 := probe.CheckAvailability(ctx)
+			Expect(err1).Should(HaveOccurred())
+
+			By("3. Verifying the second check passes because counters were reset")
+			// The probe now has 0 successes and 0 failures internally because they've been Swap-ped
+			err2 := probe.CheckAvailability(ctx)
+			Expect(err2).ShouldNot(HaveOccurred(),
+				"The second check should pass because the counters should have been reset to zero")
+		})
+	})
+})
+
+// A helper that creates a new BackendProbe and populates it with a specific number of success and failure events.
+func setupProbeWithCounts(successesCount, failuresCount int) AvailabilityProbe {
+	p := NewBackendProbe()
+	for i := 0; i < successesCount; i++ {
+		p.Success()
+	}
+	for i := 0; i < failuresCount; i++ {
+		p.Failure()
+	}
+	return p
+}

--- a/pkg/metrics/backend_probe_test.go
+++ b/pkg/metrics/backend_probe_test.go
@@ -18,51 +18,40 @@ var _ = Describe("Backend_Probe CheckAvailability unit tests", func() {
 
 	var (
 		probe AvailabilityProbe
-		ctx   context.Context
 	)
-
-	BeforeEach(func() {
-		ctx = context.TODO()
-	})
 
 	// Testing the logic determining whether a platform is successful or failing
 	When("the probe is healthy", func() {
-		It("should pass with no successes and no failures", func() {
+		It("should pass with no successes and no failures", func(ctx context.Context) {
 			probe = setupProbeWithCounts(0, 0)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 
-		It("should pass with no successes and only one failure", func() {
+		It("should pass with no successes and only one failure", func(ctx context.Context) {
 			probe = setupProbeWithCounts(0, 1)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 
-		It("should pass with many successes and no failures", func() {
+		It("should pass with many successes and no failures", func(ctx context.Context) {
 			probe = setupProbeWithCounts(20, 0)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 
-		It("should pass with a failure rate clearly below the threshold", func() {
+		It("should pass with a failure rate clearly below the threshold", func(ctx context.Context) {
 			probe = setupProbeWithCounts(10, 1) // success/failures ratio - 0.1
-			err := probe.CheckAvailability(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 	})
 
 	When("the probe is unhealthy", func() {
-		It("should fail with zero successes and multiple failures", func() {
+		It("should fail with zero successes and multiple failures", func(ctx context.Context) {
 			probe = setupProbeWithCounts(0, 2)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).Should(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(HaveOccurred())
 		})
 
-		It("should fail with a failure rate clearly above the threshold", func() {
+		It("should fail with a failure rate clearly above the threshold", func(ctx context.Context) {
 			probe = setupProbeWithCounts(10, 9) // success/failures ratio - 0.9
-			err := probe.CheckAvailability(ctx)
-			Expect(err).Should(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(HaveOccurred())
 		})
 	})
 
@@ -79,40 +68,36 @@ var _ = Describe("Backend_Probe CheckAvailability unit tests", func() {
 		failuresToPass := failuresAtEdge - 1 // A count of failures that should result in a ratio < errorThreshold
 		failuresToFail := failuresAtEdge + 1 // A count of failures that should result in a ratio > errorThreshold
 
-		It("should pass when the failure rate is just below the threshold", func() {
+		It("should pass when the failure rate is just below the threshold", func(ctx context.Context) {
 			probe := setupProbeWithCounts(baseSuccesses, failuresToPass)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 
-		It("should pass when the failure rate is exactly at the threshold", func() {
+		It("should pass when the failure rate is exactly at the threshold", func(ctx context.Context) {
 			probe := setupProbeWithCounts(baseSuccesses, failuresAtEdge)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 
-		It("should fail when the failure rate is just over the threshold", func() {
+		It("should fail when the failure rate is just over the threshold", func(ctx context.Context) {
 			probe := setupProbeWithCounts(baseSuccesses, failuresToFail)
-			err := probe.CheckAvailability(ctx)
-			Expect(err).Should(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(HaveOccurred())
 		})
 	})
 
 	// State change test
 	When("its state is checked sequentially", func() {
-		It("should reset its counters, resulting in a healthy status on the subsequent check", func() {
+		It("should reset its counters, resulting in a healthy status on the subsequent check", func(ctx context.Context) {
 			By("1. Setting up an unhealthy state")
 			probe = setupProbeWithCounts(0, 5)
 
 			By("2. Verifying the first check fails as expected")
-			err1 := probe.CheckAvailability(ctx)
-			Expect(err1).Should(HaveOccurred())
+			Expect(probe.CheckAvailability(ctx)).Should(HaveOccurred())
 
 			By("3. Verifying the second check passes because counters were reset")
 			// The probe now has 0 successes and 0 failures internally because they've been Swap-ped
-			err2 := probe.CheckAvailability(ctx)
-			Expect(err2).ShouldNot(HaveOccurred(),
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed(),
 				"The second check should pass because the counters should have been reset to zero")
+
 		})
 	})
 })
@@ -120,10 +105,10 @@ var _ = Describe("Backend_Probe CheckAvailability unit tests", func() {
 // A helper that creates a new BackendProbe and populates it with a specific number of success and failure events.
 func setupProbeWithCounts(successesCount, failuresCount int) AvailabilityProbe {
 	p := NewBackendProbe()
-	for i := 0; i < successesCount; i++ {
+	for range successesCount {
 		p.Success()
 	}
-	for i := 0; i < failuresCount; i++ {
+	for range failuresCount {
 		p.Failure()
 	}
 	return p

--- a/pkg/metrics/common_test.go
+++ b/pkg/metrics/common_test.go
@@ -1,0 +1,74 @@
+package mpcmetrics
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Common functions unit tests", func() {
+
+	// A unit test for the possibility of race conditions hitting the functions in common.go that handle the probes map.
+	// This test is designed to reliably trigger race conditions via goroutines as persistent readers and writers
+	// to the probes map, running for a controlled duration.
+	// This test's meaning of `passing` is `nothing panicked because of race conditions on probes`.
+	Describe("common.go race condition test", func() {
+
+		Context("when the probes map is accessed concurrently", func() {
+			BeforeEach(func() {
+				probes = make(map[string]*AvailabilityProbe)
+			})
+
+			It("should not have a data race", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				var wg sync.WaitGroup
+				writerCount := 5
+
+				// Persistent reader
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+							checkProbes(ctx)
+						}
+					}
+				}()
+
+				// Persistent writer
+				for i := 0; i < writerCount; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						defer GinkgoRecover()
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							default:
+								randomPlatform := fmt.Sprintf("platform-%d", rand.Intn(100))
+								CountAvailabilitySuccess(randomPlatform)
+								CountAvailabilityError(randomPlatform)
+							}
+						}
+					}()
+				}
+
+				time.Sleep(200 * time.Millisecond)
+
+				cancel()
+				wg.Wait()
+			})
+		})
+	})
+})


### PR DESCRIPTION
This pull request contains test suites for backend_probe.go -> CheckAvailability (as the Jira task was meant to be about) but also contains a separate test suite for common.go's functions which handle common.go's probes map for managing the successes and failures of platforms. 
This PR also includes a fix for the race conditions found in the tested common.go functions, proven by the test to cause a [fatal error](https://drive.google.com/file/d/1hz1Ok3MMnXDQbsaqyhuy29wyNHnP0R61/view?usp=sharing).

**CheckAvailability test suite:**
This test suite covers the only testable function in backend_probe.go - CheckAvailability.  Is split into two main sections:

1. Testing the logic of returning nothing (successful platform) or returning an error (failing platform). This is not only tested by creating conditions for a successful/failing platform, but also a boundary test for the errorThreshold constant that dynamically evaluates the boundaries to test for future robustness.

2. Test the state change of a platform as CheckAvailability is called twice, verifying the Swap() action clears all successes and failures of a probe.

**Race conditions in common.go functions test suite:**
A unit test for the possibility of race conditions hitting the functions in common.go that handle the probes map.
 This test is designed to reliably trigger race conditions via goroutines as persistent readers and writers to the probes map, running for a controlled duration.
This test's meaning of `passing` is `nothing panicked because of race conditions on probes`.

Assisted-by: Gemini