### PR TITLE
Add conflict-prone TaskRun update function and use it whenever possible

### DIFF
--- a/pkg/reconciler/taskrun/dynamic.go
+++ b/pkg/reconciler/taskrun/dynamic.go
@@ -9,8 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -100,7 +98,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 		} else if address != "" { // An IP address was successfully retrieved for the the VM
 			tr.Labels[AssignedHost] = tr.Annotations[CloudInstanceId]
 			tr.Annotations[CloudAddress] = address
-			err := taskRun.client.Update(ctx, tr)
+			err := UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 3)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -170,7 +168,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 		//no host available
 		//add the waiting label
 		tr.Labels[WaitingForPlatformLabel] = platformLabel(r.platform)
-		if err := taskRun.client.Update(ctx, tr); err != nil {
+		if err := UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 3); err != nil {
 			log.Error(err, "Failed to update task with waiting label. Will retry.")
 		}
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
@@ -203,7 +201,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 		}
 		failureCount++
 		tr.Annotations[CloudFailures] = strconv.Itoa(failureCount)
-		err = taskRun.client.Update(ctx, tr)
+		err = UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 3)
 		if err != nil {
 			//todo: handle conflict properly, for now you get an extra retry
 			log.Error(err, "failed to update failure count")
@@ -214,40 +212,21 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 	message = fmt.Sprintf("launched %s instance for %s", r.instanceTag, tr.Name)
 	r.eventRecorder.Event(tr, "Normal", "Launched", message)
 
-	//this seems super prone to conflicts
-	//we always read a new version direct from the API server on conflict
-	for {
-		tr.Annotations[CloudInstanceId] = string(instance)
-		tr.Labels[CloudDynamicPlatform] = platformLabel(r.platform)
+	// Set the instance ID and platform label, then update with conflict resilience
+	tr.Annotations[CloudInstanceId] = string(instance)
+	tr.Labels[CloudDynamicPlatform] = platformLabel(r.platform)
+	//add a finalizer to clean up
+	controllerutil.AddFinalizer(tr, PipelineFinalizer)
 
-		log.Info("updating instance id of cloud host", "instance", instance)
-		//add a finalizer to clean up
-		controllerutil.AddFinalizer(tr, PipelineFinalizer)
-		err = taskRun.client.Update(ctx, tr)
-		if err == nil {
-			break
-		} else if !errors.IsConflict(err) {
-			log.Error(err, "failed to update")
-			err2 := r.CloudProvider.TerminateInstance(taskRun.client, ctx, instance)
-			if err2 != nil {
-				log.Error(err2, "failed to delete cloud instance")
-			}
-			return reconcile.Result{}, err
-		} else {
-			log.Error(err, "conflict updating, retrying")
-			err := taskRun.apiReader.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)
-			if err != nil {
-				log.Error(err, "failed to update")
-				err2 := r.CloudProvider.TerminateInstance(taskRun.client, ctx, instance)
-				if err2 != nil {
-					log.Error(err2, "failed to delete cloud instance")
-				}
-				return reconcile.Result{}, err
-			}
-			if tr.Annotations == nil {
-				tr.Annotations = map[string]string{}
-			}
+	log.Info("updating instance id of cloud host", "instance", instance)
+	err = UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 5)
+	if err != nil {
+		log.Error(err, "failed to update TaskRun with instance ID after retries")
+		err2 := r.CloudProvider.TerminateInstance(taskRun.client, ctx, instance)
+		if err2 != nil {
+			log.Error(err2, "failed to delete cloud instance")
 		}
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{RequeueAfter: 2 * time.Minute}, nil
@@ -259,6 +238,5 @@ func (dr DynamicResolver) removeInstanceFromTask(reconcileTaskRun *ReconcileTask
 	delete(taskRun.Labels, AssignedHost)
 	delete(taskRun.Annotations, CloudInstanceId)
 	delete(taskRun.Annotations, CloudDynamicPlatform)
-	updateErr := reconcileTaskRun.client.Update(ctx, taskRun)
-	return updateErr
+	return UpdateTaskRunWithRetry(ctx, reconcileTaskRun.client, reconcileTaskRun.apiReader, taskRun, 3)
 }

--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -86,7 +86,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		//TODO: is the requeue actually a good idea?
 		//TODO: timeout
 		tr.Labels[WaitingForPlatformLabel] = platformLabel(hp.targetPlatform)
-		err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
+		err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -98,7 +98,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 	delete(tr.Labels, WaitingForPlatformLabel)
 	//add a finalizer to clean up the secret
 	controllerutil.AddFinalizer(tr, PipelineFinalizer)
-	err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
+	err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -110,7 +110,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		log.Error(err, "failed to launch provisioning task, unassigning host")
 		delete(tr.Labels, AssignedHost)
 		controllerutil.RemoveFinalizer(tr, PipelineFinalizer)
-		updateErr := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
+		updateErr := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr)
 		if updateErr != nil {
 			log.Error(updateErr, "Could not unassign task after provisioning failure")
 			return reconcile.Result{}, err

--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -86,7 +86,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		//TODO: is the requeue actually a good idea?
 		//TODO: timeout
 		tr.Labels[WaitingForPlatformLabel] = platformLabel(hp.targetPlatform)
-		err = r.client.Update(ctx, tr)
+		err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -98,7 +98,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 	delete(tr.Labels, WaitingForPlatformLabel)
 	//add a finalizer to clean up the secret
 	controllerutil.AddFinalizer(tr, PipelineFinalizer)
-	err = r.client.Update(ctx, tr)
+	err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -110,7 +110,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		log.Error(err, "failed to launch provisioning task, unassigning host")
 		delete(tr.Labels, AssignedHost)
 		controllerutil.RemoveFinalizer(tr, PipelineFinalizer)
-		updateErr := r.client.Update(ctx, tr)
+		updateErr := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
 		if updateErr != nil {
 			log.Error(updateErr, "Could not unassign task after provisioning failure")
 			return reconcile.Result{}, err

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -979,7 +979,7 @@ func UpdateTaskRunWithRetry(ctx context.Context, client client.Client, apiReader
 		return updateTaskRun(ctx, client, apiReader, tr)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update TaskRun after %d attempts, last error: %w", retry.DefaultRetry.Steps, err)
+		return fmt.Errorf("failed to update TaskRun, last error: %w", err)
 	}
 	return nil
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -970,3 +970,104 @@ type Host struct {
 func platformLabel(platform string) string {
 	return strings.ReplaceAll(platform, "/", "-")
 }
+
+// UpdateTaskRunWithRetry performs a conflict-resilient update of a TaskRun object.
+// On conflict, it fetches the latest version and merges labels, annotations, and finalizers from the incoming TaskRun.
+func UpdateTaskRunWithRetry(ctx context.Context, client client.Client, apiReader client.Reader, tr *tektonapi.TaskRun, maxRetries int) error {
+	log := logr.FromContextOrDiscard(ctx)
+	if maxRetries <= 0 {
+		maxRetries = 5
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Attempt to update the TaskRun
+		err := client.Update(ctx, tr)
+		if err == nil {
+			// Success!
+			if attempt > 0 {
+				log.Info("TaskRun update succeeded after retries", "attempts", attempt+1)
+			}
+			return nil
+		}
+
+		// Check if it's a conflict error
+		if !errors.IsConflict(err) {
+			// Non-conflict error - fail immediately
+			return fmt.Errorf("failed to update TaskRun: %w", err)
+		}
+
+		// Handle conflict error
+		lastErr = err
+		log.Info("Conflict detected, retrying update", "attempt", attempt+1, "maxRetries", maxRetries)
+
+		// If this is the last attempt, don't fetch
+		if attempt == maxRetries-1 {
+			break
+		}
+
+		// Store the desired labels, annotations, and finalizers
+		desiredLabels := make(map[string]string)
+		desiredAnnotations := make(map[string]string)
+		desiredFinalizers := make([]string, 0)
+
+		if tr.Labels != nil {
+			for k, v := range tr.Labels {
+				desiredLabels[k] = v
+			}
+		}
+		if tr.Annotations != nil {
+			for k, v := range tr.Annotations {
+				desiredAnnotations[k] = v
+			}
+		}
+		if tr.Finalizers != nil {
+			desiredFinalizers = append(desiredFinalizers, tr.Finalizers...)
+		}
+
+		// Fetch the latest version of the TaskRun
+		namespacedName := types.NamespacedName{
+			Namespace: tr.Namespace,
+			Name:      tr.Name,
+		}
+
+		if err := apiReader.Get(ctx, namespacedName, tr); err != nil {
+			return fmt.Errorf("failed to fetch latest TaskRun version: %w", err)
+		}
+
+		// Ensure maps exist
+		if tr.Labels == nil {
+			tr.Labels = make(map[string]string)
+		}
+		if tr.Annotations == nil {
+			tr.Annotations = make(map[string]string)
+		}
+		if tr.Finalizers == nil {
+			tr.Finalizers = make([]string, 0)
+		}
+
+		// Merge desired labels and annotations into the fresh TaskRun
+		for k, v := range desiredLabels {
+			tr.Labels[k] = v
+		}
+		for k, v := range desiredAnnotations {
+			tr.Annotations[k] = v
+		}
+
+		// Merge finalizers (avoid duplicates)
+		for _, finalizer := range desiredFinalizers {
+			found := false
+			for _, existing := range tr.Finalizers {
+				if existing == finalizer {
+					found = true
+					break
+				}
+			}
+			if !found {
+				tr.Finalizers = append(tr.Finalizers, finalizer)
+			}
+		}
+	}
+
+	return fmt.Errorf("failed to update TaskRun after %d attempts, last error: %w", maxRetries, lastErr)
+}


### PR DESCRIPTION
In previuos PR, I have deleted some intermediate TaskRun updates, because each update schedules the new reconcilliation, right, and we don't neeed this, since they seems may start in parallel (yes documentation says no but in practice we can still see it) 

but, TaskRun is not exclusive for MPC, so tekton controller also updating them

so, now when the code reaches to the final very important TR update - when the instance ID and/or IP set, it often catches the conflict exception. and this i info is missing. 

so all starts over again, but the VM provisioned in 1st turn become an zombie..

This PR introduces the conflict-resillient update fuction