### PR TITLE
Enable ARM64 builds for multi-platform-controller

### DIFF
--- a/.tekton/multi-platform-controller-pull-request.yaml
+++ b/.tekton/multi-platform-controller-pull-request.yaml
@@ -28,6 +28,10 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -128,6 +132,11 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
     results:
     - description: ''
       name: IMAGE_URL
@@ -208,7 +217,12 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
       params:
       - name: IMAGE
         value: $(params.output-image)
@@ -231,14 +245,16 @@ spec:
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
+      - name: IMAGE_APPEND_PLATFORM
+        value: 'true'
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: buildah-remote
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:977ebe581158e184504fb5886f534812b91cc3e79445be48449f5b7cfd14f034
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote@sha256:9c772f152e24c01694910c8ddd92edf2946ac70d36731f7bce766d8b17b1b546
         - name: kind
           value: task
         resolver: bundles
@@ -259,12 +275,12 @@ spec:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
       - name: ALWAYS_BUILD_INDEX
-        value: $(params.build-image-index)
+        value: 'true'
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-images.results.IMAGE_REF[*])
       runAfter:
-      - build-container
+      - build-images
       taskRef:
         params:
         - name: name

--- a/.tekton/multi-platform-controller-push.yaml
+++ b/.tekton/multi-platform-controller-push.yaml
@@ -25,6 +25,10 @@ spec:
     value: quay.io/redhat-user-workloads/rhtap-build-tenant/multi-platform-controller/multi-platform-controller:{{revision}}
   - name: dockerfile
     value: Dockerfile
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -125,6 +129,11 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
     results:
     - description: ''
       name: IMAGE_URL
@@ -205,7 +214,12 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
       params:
       - name: IMAGE
         value: $(params.output-image)
@@ -228,14 +242,16 @@ spec:
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
+      - name: IMAGE_APPEND_PLATFORM
+        value: 'true'
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: buildah-remote
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.4@sha256:977ebe581158e184504fb5886f534812b91cc3e79445be48449f5b7cfd14f034
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote@sha256:9c772f152e24c01694910c8ddd92edf2946ac70d36731f7bce766d8b17b1b546
         - name: kind
           value: task
         resolver: bundles
@@ -256,12 +272,12 @@ spec:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.image-expires-after)
       - name: ALWAYS_BUILD_INDEX
-        value: $(params.build-image-index)
+        value: 'true'
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-images.results.IMAGE_REF[*])
       runAfter:
-      - build-container
+      - build-images
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
This PR enables ARM64 support for the multi-platform-controller using the matrix build pattern.

## Changes Made

- Add `build-platforms` parameter with `linux/x86_64` and `linux/arm64` to both push and PR pipelines
- Convert single `build-container` task to matrix `build-images` task for multi-platform builds
- Switch from `buildah` to `buildah-remote` task for multi-platform support
- Update `build-image-index` task to collect all platform images using `IMAGE_REF[*]`
- Preserve `PRIVILEGED_NESTED` parameter required for multi-platform-controller operations
- Enable ARM64 builds for both production (push) and development (PR) workflows

## Why This Matters

This resolves the critical paradox where the multi-platform-controller (which orchestrates ARM builds for other repositories) couldn't run on ARM systems itself. With these changes, the multi-platform-controller can:

- Build ARM64 images for production deployments
- Build ARM64 images for development/testing 
- Run on ARM64 Kubernetes clusters
- Properly orchestrate ARM builds for other Konflux components

## Testing

The changes follow the established pattern used by other Konflux repositories like `oras-container` that already have ARM64 support enabled.

Fixes the multi-platform-controller ARM64 support gap identified in the Konflux ARM64 enablement effort.