### PR TITLE
Reduce likelihood conflicts prevents TaskRun update

### DIFF
--- a/pkg/reconciler/taskrun/dynamic.go
+++ b/pkg/reconciler/taskrun/dynamic.go
@@ -98,7 +98,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 		} else if address != "" { // An IP address was successfully retrieved for the the VM
 			tr.Labels[AssignedHost] = tr.Annotations[CloudInstanceId]
 			tr.Annotations[CloudAddress] = address
-			err := UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 3)
+			err := UpdateTaskRunWithRetry(ctx, taskRun.client, tr)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -168,7 +168,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 		//no host available
 		//add the waiting label
 		tr.Labels[WaitingForPlatformLabel] = platformLabel(r.platform)
-		if err := UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 3); err != nil {
+		if err := UpdateTaskRunWithRetry(ctx, taskRun.client, tr); err != nil {
 			log.Error(err, "Failed to update task with waiting label. Will retry.")
 		}
 		return reconcile.Result{RequeueAfter: time.Minute}, nil
@@ -201,7 +201,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 		}
 		failureCount++
 		tr.Annotations[CloudFailures] = strconv.Itoa(failureCount)
-		err = UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 3)
+		err = UpdateTaskRunWithRetry(ctx, taskRun.client, tr)
 		if err != nil {
 			//todo: handle conflict properly, for now you get an extra retry
 			log.Error(err, "failed to update failure count")
@@ -219,7 +219,7 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 	controllerutil.AddFinalizer(tr, PipelineFinalizer)
 
 	log.Info("updating instance id of cloud host", "instance", instance)
-	err = UpdateTaskRunWithRetry(ctx, taskRun.client, taskRun.apiReader, tr, 5)
+	err = UpdateTaskRunWithRetry(ctx, taskRun.client, tr)
 	if err != nil {
 		log.Error(err, "failed to update TaskRun with instance ID after retries")
 		err2 := r.CloudProvider.TerminateInstance(taskRun.client, ctx, instance)
@@ -238,5 +238,5 @@ func (dr DynamicResolver) removeInstanceFromTask(reconcileTaskRun *ReconcileTask
 	delete(taskRun.Labels, AssignedHost)
 	delete(taskRun.Annotations, CloudInstanceId)
 	delete(taskRun.Annotations, CloudDynamicPlatform)
-	return UpdateTaskRunWithRetry(ctx, reconcileTaskRun.client, reconcileTaskRun.apiReader, taskRun, 3)
+	return UpdateTaskRunWithRetry(ctx, reconcileTaskRun.client, taskRun)
 }

--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -86,7 +86,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		//TODO: is the requeue actually a good idea?
 		//TODO: timeout
 		tr.Labels[WaitingForPlatformLabel] = platformLabel(hp.targetPlatform)
-		err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
+		err = UpdateTaskRunWithRetry(ctx, r.client, tr)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -98,7 +98,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 	delete(tr.Labels, WaitingForPlatformLabel)
 	//add a finalizer to clean up the secret
 	controllerutil.AddFinalizer(tr, PipelineFinalizer)
-	err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
+	err = UpdateTaskRunWithRetry(ctx, r.client, tr)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -110,7 +110,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		log.Error(err, "failed to launch provisioning task, unassigning host")
 		delete(tr.Labels, AssignedHost)
 		controllerutil.RemoveFinalizer(tr, PipelineFinalizer)
-		updateErr := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr, 3)
+		updateErr := UpdateTaskRunWithRetry(ctx, r.client, tr)
 		if updateErr != nil {
 			log.Error(updateErr, "Could not unassign task after provisioning failure")
 			return reconcile.Result{}, err


### PR DESCRIPTION
TaskRuns are updated by multiple controllers. This can cause Conflict errors that break the workflow of the Multi-Platform Controller.

With this change the Reconciler will retry applying the changes it needs to make to the TaskRun, reducing the likelihood its workflow is interrupted. In the unlucky case the retry mechanism fails, we'll still see failures. We expect the likelihood of this happening to be very small. 

Supersedes #492 adding on top of it some logic to restrict the update logic only to well-known labels/annotations/finalizers.