### PR TITLE
KONFLUX-9230: Fix cloud.go -> ValidateTaskRunID does not invalidating faulty TaskRunIDs

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,9 @@ const (
 	OKState       VMState = "OK"
 	FailedState   VMState = "FAILED"
 )
+
+// Regular expression for RFC 1123 Label Names, used for K8s namespaces validation for ValidateTaskRunID.
+var rfc1123Regex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 type CloudProvider interface {
 	LaunchInstance(kubeClient client.Client, ctx context.Context, taskRunID string, instanceTag string, additionalInstanceTags map[string]string) (InstanceIdentifier, error)
@@ -37,11 +41,45 @@ type CloudVMInstance struct {
 type InstanceIdentifier string
 type VMState string
 
+// validateRFC1123 checks if a string is a valid according to Kubernetes namespace restrictions.
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#namespaces-and-dns
+// It returns an error message string if invalid, or an empty string if valid.
+func validateRFC1123(labelType, label string) error {
+	if len(label) > 63 {
+		return fmt.Errorf("%s part '%s' is too long for a Kubernetes label (max 63 chars)", labelType, label)
+	}
+	if !rfc1123Regex.MatchString(label) {
+		return fmt.Errorf("%s part '%s' is not a valid RFC 1123 label (must be lowercase alphanumeric characters"+
+			" or '-', and must start and end with an alphanumeric character)", labelType, label)
+	}
+	return nil
+}
+
 // ValidateTaskRunID ensures that a TaskRunId string is in the following format: '<TaskRun Namespace>:<TaskRun Name>'
+// It also validates that the ID conforms to cloud provider tagging rules and Kubernetes naming conventions.
 func ValidateTaskRunID(taskRunID string) error {
-	if strings.Count(taskRunID, ":") == 1 {
-		return nil
+	// Check against the most restrictive rule - IBM Cloud/AWS string length rule
+	if len(taskRunID) > 128 {
+		return fmt.Errorf("taskRunID '%s' cannot be longer than 128 chars", taskRunID)
+	}
+	// AWS tags cannot start with 'aws:' (case-insensitive)
+	if strings.HasPrefix(strings.ToLower(taskRunID), "aws:") {
+		return fmt.Errorf("taskRunID '%s' cannot start with 'aws:' (case-insensitive) as per AWS tag restrictions",
+			taskRunID)
 	}
 
-	return fmt.Errorf("'%s' does not follow the correct format: '<TaskRun Namespace>:<TaskRun Name>'", taskRunID)
+	// Validate the '<namespace>:<name>' structure
+	parts := strings.Split(taskRunID, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("'%s' does not follow the correct format: '<TaskRun Namespace>:<TaskRun Name>', "+
+			"neither the namespace nor the name can be empty", taskRunID)
+	}
+
+	namespace := parts[0]
+	// Validate namespace against Kubernetes RFC 1123 standard
+	if err := validateRFC1123("namespace", namespace); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1,37 +1,48 @@
 package cloud
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"strings"
 )
 
-// A unit test for ValidateTaskRunID. For now only tests input that should not return an error from ValidateTaskRunID
-// and input that should return an error code, according to ValidateTaskRunID's current logic.
+// A unit test for ValidateTaskRunID. Checks for a simple valid TaskRunID that should pass, and has a large table-driven
+// test checking the various aspects of the validation logic - constraints from individual cloud providers, constraints
+// on namespace names in Kubernetes etc. The invalidation tests not only verify that an error occurred but that the
+// error message accurately reflects what failed the TaskRunID.
 var _ = Describe("ValidateTaskRunID", func() {
 
-	// Testing everything that should pass, according to ValidateTaskRunID's current code
-	When("the TaskRunID is in the standard 'namespace:name' format", func() {
-		It("should return no error", func() {
-			input := "my-namespace:my-taskrun-123"
-			err := ValidateTaskRunID(input)
-			Expect(err).Should(BeNil())
+	When("the TaskRunID is valid", func() {
+		It("should not return an error for a standard 'namespace:name' format", func() {
+			err := ValidateTaskRunID("my-namespace:my-taskrun-123")
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
-	// Testing what ValidateTaskRunID shouldn't pass according to its current code
-	When("the TaskRunID fails the 'single colon' structural requirement", func() {
-		DescribeTable("it should return a formatted error",
-			func(input string, descriptionOfInvalidity string) {
-				expectedErr := fmt.Errorf(
-					"'%s' does not follow the correct format: '<TaskRun Namespace>:<TaskRun Name>'", input)
-				Expect(ValidateTaskRunID(input)).To(MatchError(expectedErr), descriptionOfInvalidity)
+	When("the TaskRunID is invalid", func() {
+		DescribeTable("it should return a descriptive error",
+			func(input string, expectedErrSubstring string) {
+				Expect(ValidateTaskRunID(input)).To(MatchError(ContainSubstring(expectedErrSubstring)))
 			},
-			Entry("no colons", "nocolonshere", "Zero colons"),
-			Entry("empty string", "", "Empty string, zero colons"),
-			Entry("single space string", " ", "Single space, zero colons"),
-			Entry("too many colons", "too:many:colons:in:this:id", "Multiple colons"),
-			Entry("only colons", ":::", "Multiple colons, no other content"),
+			// Structural format errors
+			Entry("when the string is empty", "", "neither the namespace nor the name can be empty"),
+			Entry("when there are no colons", "nocolonshere", "does not follow the correct format"),
+			Entry("when there are too many colons", "too:many:colons", "does not follow the correct format"),
+			Entry("when the namespace part is empty", ":a-taskrun-name", "neither the namespace nor the name can be empty"),
+			Entry("when the name part is empty", "a-namespace:", "neither the namespace nor the name can be empty"),
+			Entry("when it's just a colon", ":", "neither the namespace nor the name can be empty"),
+
+			// Cloud provider rule violations
+			Entry("when the tag is too long (>128 chars)", strings.Repeat("i", 70)+":"+strings.Repeat("j", 60), "cannot be longer than 128 chars"),
+			Entry("when the tag has 'aws:' prefix", "aws:my-task", "cannot start with 'aws:'"),
+			Entry("when the tag has 'AWS:' prefix (case-insensitive)", "AWS:my-task", "cannot start with 'aws:'"),
+
+			// Kubernetes RFC 1123 violations
+			Entry("when the namespace is too long (>63 chars)", strings.Repeat("a", 64)+":task-name", "is too long for a Kubernetes label"),
+			Entry("when the namespace contains an illegal character '$'", "moshe$kipod:my-task", "is not a valid RFC 1123 label"),
+			Entry("when the namespace contains uppercase characters", "CamelCaseNamespace:my-task", "is not a valid RFC 1123 label"),
+			Entry("when the namespace starts with a hyphen", "-namespace:my-task", "is not a valid RFC 1123 label"),
+			Entry("when the namespace ends with a hyphen", "namespace-:my-task", "is not a valid RFC 1123 label"),
 		)
 	})
 })


### PR DESCRIPTION
First commit for KONFLUX-9230 with initial code for review. 
Contains a fix for the missing validations on TaskRunID such as IBM Cloud and AWS requirements for tag strings (what the TaskRunID is later used for) and validation of the namespace part of the TaskRunID according to RFC 1123 standard.
Also added specs to ValidateTaskRunID's unit test to test the new code.

Assisted-by: Gemini over Continue.dev