### PR TITLE
Make MPC running_tasks and waiting_tasks metrics to contain source namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
+	github.com/prometheus/client_model v0.6.1
 	github.com/tektoncd/pipeline v0.62.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.36.0
@@ -103,7 +104,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect

--- a/pkg/metrics/platform.go
+++ b/pkg/metrics/platform.go
@@ -2,6 +2,7 @@ package mpcmetrics
 
 import (
 	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -20,8 +21,8 @@ type PlatformMetrics struct {
 	AllocationTime         prometheus.Histogram
 	WaitTime               prometheus.Histogram
 	TaskRunTime            prometheus.Histogram
-	RunningTasks           prometheus.Gauge
-	WaitingTasks           prometheus.Gauge
+	RunningTasks           *prometheus.GaugeVec
+	WaitingTasks           *prometheus.GaugeVec
 	ProvisionFailures      prometheus.Counter
 	CleanupFailures        prometheus.Counter
 	HostAllocationFailures prometheus.Counter
@@ -62,23 +63,28 @@ func RegisterPlatformMetrics(_ context.Context, platform string) error {
 	if err := metrics.Registry.Register(pmetrics.TaskRunTime); err != nil {
 		return err
 	}
-
-	pmetrics.RunningTasks = prometheus.NewGauge(prometheus.GaugeOpts{
-		ConstLabels: map[string]string{"platform": platform},
-		Subsystem:   MetricsSubsystem,
-		Name:        "running_tasks",
-		Help:        "The number of currently running tasks on this platform"})
+	// TODO: add namespace of the task run
+	pmetrics.RunningTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: MetricsSubsystem,
+		Name:      "running_tasks",
+		Help:      "The number of currently running tasks on this platform",
+	}, []string{"platform", "namespace"})
 	if err := metrics.Registry.Register(pmetrics.RunningTasks); err != nil {
-		return err
+		// This can be called multiple times, so we need to check if it's already registered
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			return err
+		}
 	}
-
-	pmetrics.WaitingTasks = prometheus.NewGauge(prometheus.GaugeOpts{
-		ConstLabels: map[string]string{"platform": platform},
-		Subsystem:   MetricsSubsystem,
-		Name:        "waiting_tasks",
-		Help:        "The number of tasks waiting for an executor to be available to run"})
+	// TODO: add namespace of the task run
+	pmetrics.WaitingTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: MetricsSubsystem,
+		Name:      "waiting_tasks",
+		Help:      "The number of tasks waiting for an executor to be available to run",
+	}, []string{"platform", "namespace"})
 	if err := metrics.Registry.Register(pmetrics.WaitingTasks); err != nil {
-		return err
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			return err
+		}
 	}
 
 	pmetrics.ProvisionFailures = prometheus.NewCounter(prometheus.CounterOpts{

--- a/pkg/metrics/platform.go
+++ b/pkg/metrics/platform.go
@@ -63,7 +63,7 @@ func RegisterPlatformMetrics(_ context.Context, platform string) error {
 	if err := metrics.Registry.Register(pmetrics.TaskRunTime); err != nil {
 		return err
 	}
-	// TODO: add namespace of the task run
+
 	pmetrics.RunningTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: MetricsSubsystem,
 		Name:      "running_tasks",
@@ -75,7 +75,7 @@ func RegisterPlatformMetrics(_ context.Context, platform string) error {
 			return err
 		}
 	}
-	// TODO: add namespace of the task run
+
 	pmetrics.WaitingTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: MetricsSubsystem,
 		Name:      "waiting_tasks",

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -534,7 +534,7 @@ func (r *ReconcileTaskRun) handleHostAllocation(ctx context.Context, tr *tektona
 		log.Info("host assigned successfully", "host", assignedHost)
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
 			metrics.AllocationTime.Observe(float64(time.Now().Unix() - startTime))
-			metrics.RunningTasks.Inc()
+			metrics.RunningTasks.WithLabelValues(platformLabel(targetPlatform), tr.Namespace).Inc()
 		})
 	}
 
@@ -543,12 +543,12 @@ func (r *ReconcileTaskRun) handleHostAllocation(ctx context.Context, tr *tektona
 		log.Info("task no longer waiting - host allocated")
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
 			metrics.WaitTime.Observe(float64(time.Now().Unix() - tr.CreationTimestamp.Unix()))
-			metrics.WaitingTasks.Dec()
+			metrics.WaitingTasks.WithLabelValues(platformLabel(targetPlatform), tr.Namespace).Dec()
 		})
 	} else if !wasWaiting && isWaiting {
 		log.Info("task now waiting for host")
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
-			metrics.WaitingTasks.Inc()
+			metrics.WaitingTasks.WithLabelValues(platformLabel(targetPlatform), tr.Namespace).Inc()
 		})
 	} else if wasWaiting && isWaiting {
 		log.V(1).Info("task still waiting for host")
@@ -599,7 +599,7 @@ func (r *ReconcileTaskRun) handleHostAssigned(ctx context.Context, tr *tektonapi
 	taskRunDuration := time.Now().Unix() - tr.CreationTimestamp.Unix()
 	mpcmetrics.HandleMetrics(platform, func(metrics *mpcmetrics.PlatformMetrics) {
 		metrics.TaskRunTime.Observe(float64(taskRunDuration))
-		metrics.RunningTasks.Dec()
+		metrics.RunningTasks.WithLabelValues(platformLabel(platform), tr.Namespace).Dec()
 	})
 
 	// Attempt host deallocation


### PR DESCRIPTION
## What
Converted the `RunningTasks` and `WaitingTasks` metrics from `Gauge` to **`GaugeVec`**. This change includes all necessary code updates to support the new metric type.

## Why
To enable the addition of a **`source_namespace` label** to `multi_platform_controller_running_tasks` and `multi_platform_controller_waiting_tasks`. This label will significantly improve Konflux support's ability to monitor resource utilization, allowing them to easily identify which tenants are consuming the most VM resources or experiencing the longest wait times.