### PR TITLE
changed namespace to taskrun_namespace to avoid ambiguity

### DIFF
--- a/pkg/metrics/platform.go
+++ b/pkg/metrics/platform.go
@@ -68,7 +68,7 @@ func RegisterPlatformMetrics(_ context.Context, platform string) error {
 		Subsystem: MetricsSubsystem,
 		Name:      "running_tasks",
 		Help:      "The number of currently running tasks on this platform",
-	}, []string{"platform", "namespace"})
+	}, []string{"platform", "taskrun_namespace"})
 	if err := metrics.Registry.Register(pmetrics.RunningTasks); err != nil {
 		// This can be called multiple times, so we need to check if it's already registered
 		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
@@ -80,7 +80,7 @@ func RegisterPlatformMetrics(_ context.Context, platform string) error {
 		Subsystem: MetricsSubsystem,
 		Name:      "waiting_tasks",
 		Help:      "The number of tasks waiting for an executor to be available to run",
-	}, []string{"platform", "namespace"})
+	}, []string{"platform", "taskrun_namespace"})
 	if err := metrics.Registry.Register(pmetrics.WaitingTasks); err != nil {
 		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
 			return err

--- a/pkg/metrics/platform_test.go
+++ b/pkg/metrics/platform_test.go
@@ -169,7 +169,7 @@ func getGaugeValue(platform, metricName, namespace string) (int, error) {
 				if m.Gauge == nil {
 					continue
 				}
-				if hasLabel(m.Label, "platform", platform) && hasLabel(m.Label, "namespace", namespace) {
+				if hasLabel(m.Label, "platform", platform) && hasLabel(m.Label, "taskrun_namespace", namespace) {
 					return int(m.Gauge.GetValue()), nil
 				}
 			}


### PR DESCRIPTION
## What
Changed `namespace` to `taskrun_namespace` in `RunningTasks` and `WaitingTasks`
## Why
In metrics `multi_platform_controller_running_tasks` and `multi_platform_controller_waiting_tasks` there's already a `namespace` label (a constant one), to avoid amibugity, I changed the lable name to taskrun_namespace.