### PR TITLE
KFLUXINFRA-2004 and KONFLUX-9460 - taskrun_test.go refactoring etc.

### DIFF
--- a/pkg/reconciler/taskrun/dynamicpool.go
+++ b/pkg/reconciler/taskrun/dynamicpool.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type DynamicHostPool struct {
@@ -108,16 +109,17 @@ func (a DynamicHostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if len(hostPool.hosts) > 0 {
-		_, err = hostPool.Allocate(r, ctx, tr, secretName)
-		if err != nil {
-			log.Error(err, "could not allocate host from pool")
-		}
-		if tr.Labels == nil || tr.Labels[WaitingForPlatformLabel] == "" {
 
-			log.Info("returning, as task is not waiting for a host")
-			//We only need to launch an instance if the task run is waiting for a label
-			return reconcile.Result{}, err
+	var allocationErr error
+	if len(hostPool.hosts) > 0 {
+		_, allocationErr = hostPool.Allocate(r, ctx, tr, secretName)
+		if allocationErr != nil && !errors.Is(allocationErr, ErrAllHostsFailed) {
+			log.Error(allocationErr, "could not allocate host from pool")
+			return reconcile.Result{}, allocationErr
+		}
+		if allocationErr == nil && (tr.Labels == nil || tr.Labels[WaitingForPlatformLabel] == "") {
+			log.Info("successfully allocated host from existing pool")
+			return reconcile.Result{}, nil
 		}
 	}
 	log.Info("could not allocate existing host, attempting to start a new one")
@@ -130,9 +132,9 @@ func (a DynamicHostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *
 	log.Info(fmt.Sprintf("%d instances running", count))
 	// We don't count old instances towards the total, as they will shut down soon
 	if count-oldInstanceCount >= a.maxInstances {
-		log.Info("cannot provision new instances")
-		// Too many instances, we just have to wait
-		return reconcile.Result{RequeueAfter: time.Minute}, err
+		log.Info("cannot provision new instances, pool is at capacity")
+		// Pool is full, and we couldn't allocate. Return the original allocation error.
+		return reconcile.Result{RequeueAfter: time.Minute}, allocationErr
 	}
 	name, err := getRandomString(8)
 	if err != nil {
@@ -150,8 +152,9 @@ func (a DynamicHostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *
 	}
 
 	log.Info("allocated instance", "instance", inst)
-	return reconcile.Result{RequeueAfter: time.Minute}, err
-
+	// The operation to launch a new instance was successful, so we return nil.
+	// The reconciler will requeue and assign the new instance once it's ready.
+	return reconcile.Result{RequeueAfter: time.Minute}, nil
 }
 
 func getRandomString(length int) (string, error) {

--- a/pkg/reconciler/taskrun/dynamicpool.go
+++ b/pkg/reconciler/taskrun/dynamicpool.go
@@ -6,13 +6,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type DynamicHostPool struct {

--- a/pkg/reconciler/taskrun/hostpool.go
+++ b/pkg/reconciler/taskrun/hostpool.go
@@ -60,7 +60,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 	// We need to track two separate conditions:
 	// 1. If any hosts for the platform exist at all.
 	// 2. If all hosts that do exist have already failed.
-	platformExists := false
+	platformHostsExists := false
 	allPlatformHostsFailed := true
 	for k, v := range hp.hosts {
 
@@ -69,7 +69,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 			continue
 		}
 		// At this point, we know at least one host for the platform exists.
-		platformExists = true
+		platformHostsExists = true
 
 		if slices.Contains(failed, k) {
 			log.Info("ignoring already failed host", "host", k, "targetPlatform", hp.targetPlatform, "hostPlatform", v.Platform)
@@ -87,7 +87,7 @@ func (hp HostPool) Allocate(r *ReconcileTaskRun, ctx context.Context, tr *v1.Tas
 		}
 	}
 	// If no hosts for the platform were found at all, return the original error.
-	if !platformExists {
+	if !platformHostsExists {
 		log.Info("no hosts with requested platform", "platform", hp.targetPlatform)
 		return reconcile.Result{}, fmt.Errorf("no hosts configured for platform %s", hp.targetPlatform)
 	}

--- a/pkg/reconciler/taskrun/provision_dynamic_test.go
+++ b/pkg/reconciler/taskrun/provision_dynamic_test.go
@@ -6,6 +6,7 @@
 package taskrun
 
 import (
+	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,6 +25,9 @@ var _ = Describe("Test Dynamic Host Provisioning", func() {
 
 	BeforeEach(func() {
 		client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
+		cloudImpl.Instances = map[cloud.InstanceIdentifier]MockInstance{}
+		cloudImpl.Running = 0
+		cloudImpl.Terminated = 0
 	})
 
 	When("when dynamic host provisioning is set to succeed", func() {

--- a/pkg/reconciler/taskrun/provision_dynamic_test.go
+++ b/pkg/reconciler/taskrun/provision_dynamic_test.go
@@ -1,0 +1,165 @@
+// This file contains all the tests for the dynamic host provisioning logic.
+// It covers the lifecycle of on-demand cloud instances, including allocation,
+// failure handling (e.g., timeouts, mid-provision failures), and eventual
+// termination, using a mock cloud provider to simulate these interactions.
+
+package taskrun
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Test Dynamic Host Provisioning", func() {
+
+	var client runtimeclient.Client
+	var reconciler *ReconcileTaskRun
+
+	BeforeEach(func() {
+		client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
+	})
+
+	When("when dynamic host provisioning is set to succeed", func() {
+
+		// It verifies that the dynamic host configuration, including additional
+		// instance tags, is parsed correctly from the main ConfigMap.
+		It("the ConfigMap should be parsed correctly", func(ctx SpecContext) {
+			configIface, err := reconciler.readConfiguration(ctx, "linux/arm64", userNamespace)
+			config := configIface.(DynamicResolver)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.additionalInstanceTags).Should(HaveKeyWithValue("foo", "bar"))
+			Expect(config.additionalInstanceTags).Should(HaveKeyWithValue("key", "value"))
+		})
+
+		// It tests the full happy-path for dynamic provisioning:
+		// 1. A user TaskRun is created.
+		// 2. A cloud instance is launched via the mock provider.
+		// 3. A provisioner TaskRun is created to set up the new instance.
+		// 4. The provisioner succeeds.
+		// 5. The user TaskRun completes.
+		// 6. The cloud instance is terminated as part of cleanup.
+		It("should allocate a cloud host correctly", func(ctx SpecContext) {
+			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-dynamic-alloc")
+			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+			params := map[string]string{}
+			for _, i := range provision.Spec.Params {
+				params[i.Name] = i.Value.StringVal
+			}
+			Expect(params["SECRET_NAME"]).Should(Equal("multi-platform-ssh-test-dynamic-alloc"))
+			Expect(params["TASKRUN_NAME"]).Should(Equal("test-dynamic-alloc"))
+			Expect(params["NAMESPACE"]).Should(Equal(userNamespace))
+			Expect(params["USER"]).Should(Equal("root"))
+			Expect(params["HOST"]).Should(Equal("test-dynamic-alloc.host.com"))
+
+			_, ok := cloudImpl.Instances[("test-dynamic-alloc")]
+			Expect(ok).Should(Equal(true))
+			Expect(cloudImpl.Instances[("test-dynamic-alloc")].Address).Should(Equal("test-dynamic-alloc.host.com"))
+			Expect(cloudImpl.Instances[("test-dynamic-alloc")].taskRun).Should(Equal("test-dynamic-alloc task run"))
+
+			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
+
+			Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).ShouldNot(HaveOccurred())
+			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			tr.Status.SetCondition(&apis.Condition{
+				Type:               apis.ConditionSucceeded,
+				Status:             "True",
+				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
+			})
+			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, ok = cloudImpl.Instances[("multi-platform-builder-test-dynamic-alloc")]
+			Expect(ok).Should(Equal(false))
+		})
+	})
+
+	When("when provisioning fails", func() {
+
+		// It simulates a scenario where the mock cloud provider fails to return
+		// an address for a newly launched instance. The test verifies that the
+		// reconciler correctly identifies this as a failure, cleans up the
+		// orphaned instance, and does not assign a host to the TaskRun.
+		It("should handle instance address failure correctly", func(ctx SpecContext) {
+			cloudImpl.FailGetAddress = true
+			defer func() { cloudImpl.FailGetAddress = false }()
+
+			createUserTaskRun(ctx, GinkgoT(), client, "test-addr-fail", "linux/arm64")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-addr-fail"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-addr-fail"}})
+			Expect(err).Should(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-addr-fail"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			tr := getUserTaskRun(ctx, GinkgoT(), client, "test-addr-fail")
+			Expect(tr.Labels[AssignedHost]).Should(BeEmpty())
+			Expect(cloudImpl.Running).Should(Equal(0))
+			_, ok := cloudImpl.Instances[("multi-platform-builder-test-addr-fail")]
+			Expect(ok).Should(Equal(false))
+		})
+
+		// It simulates a scenario where launching a cloud instance times out.
+		// The test verifies that the reconciler retries for a configured duration
+		// before ultimately failing the TaskRun and cleaning up the orphaned instance.
+		It("should handle instance timeout correctly", func(ctx SpecContext) {
+			cloudImpl.TimeoutGetAddress = true
+			defer func() { cloudImpl.TimeoutGetAddress = false }()
+
+			createUserTaskRun(ctx, GinkgoT(), client, "test-timeout", "linux/arm64")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-timeout"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-timeout"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-timeout"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			time.Sleep(time.Second)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-timeout"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			time.Sleep(time.Second * 2)
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-timeout"}})
+			Expect(err).Should(HaveOccurred())
+			tr := getUserTaskRun(ctx, GinkgoT(), client, "test-timeout")
+			Expect(tr.Labels[AssignedHost]).Should(BeEmpty())
+			Expect(cloudImpl.Running).Should(Equal(0))
+			_, ok := cloudImpl.Instances[("multi-platform-builder-test-timeout")]
+			Expect(ok).Should(Equal(false))
+		})
+
+		// It tests the cleanup logic for a scenario where a user TaskRun fails
+		// after a cloud instance has already been allocated but before the
+		// provisioner has finished. This ensures that no orphaned cloud
+		// instances are left running.
+		It("should handle provision failure in the middle correctly", func(ctx SpecContext) {
+			createUserTaskRun(ctx, GinkgoT(), client, "test-mid-fail", "linux/arm64")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-mid-fail"}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			tr := getUserTaskRun(ctx, GinkgoT(), client, "test-mid-fail")
+			if tr.Labels[AssignedHost] == "" {
+				Expect(tr.Annotations[CloudInstanceId]).ShouldNot(BeEmpty())
+			}
+			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			tr.Status.SetCondition(&apis.Condition{
+				Type:               apis.ConditionSucceeded,
+				Status:             "False",
+				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
+			})
+			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, ok := cloudImpl.Instances[("multi-platform-builder-test-mid-fail")]
+			Expect(ok).Should(Equal(false))
+			Expect(cloudImpl.Running).Should(Equal(0))
+		})
+	})
+})

--- a/pkg/reconciler/taskrun/provision_dynamicpool_test.go
+++ b/pkg/reconciler/taskrun/provision_dynamicpool_test.go
@@ -1,0 +1,165 @@
+// This file contains tests for the dynamic host pool provisioning strategy.
+// It validates the management of a warm pool of running instances, including
+// allocation from the pool, failure handling (e.g., an instance from the pool
+// fails and must be replaced), and ensuring the pool maintains its desired capacity.
+
+package taskrun
+
+import (
+	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Test Dynamic Pool Host Provisioning", func() {
+
+	var client runtimeclient.Client
+	var reconciler *ReconcileTaskRun
+
+	BeforeEach(func() {
+		client, reconciler = setupClientAndReconciler(createDynamicPoolHostConfig())
+		// Clear out any instances from previous tests
+		cloudImpl.Instances = map[cloud.InstanceIdentifier]MockInstance{}
+		cloudImpl.Running = 0
+		cloudImpl.Terminated = 0
+	})
+
+	// It tests the happy path for the dynamic pool: a TaskRun is created,
+	// it gets assigned an instance from the pool, the provisioner succeeds,
+	// and after completion, the instance is returned to the pool (not terminated).
+	It("should allocate a cloud host with dynamic pool correctly", func(ctx SpecContext) {
+		tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-dyn-pool")
+		provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+		params := map[string]string{}
+		for _, i := range provision.Spec.Params {
+			params[i.Name] = i.Value.StringVal
+		}
+		Expect(params["SECRET_NAME"]).To(Equal("multi-platform-ssh-test-dyn-pool"))
+		Expect(params["TASKRUN_NAME"]).To(Equal("test-dyn-pool"))
+		Expect(params["NAMESPACE"]).To(Equal(userNamespace))
+		Expect(params["USER"]).To(Equal("root"))
+		Expect(params["HOST"]).Should(ContainSubstring(".host.com"))
+
+		runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
+
+		Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).ShouldNot(HaveOccurred())
+		tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+		tr.Status.SetCondition(&apis.Condition{
+			Type:               apis.ConditionSucceeded,
+			Status:             "True",
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
+		})
+		Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(len(cloudImpl.Instances)).Should(Equal(1))
+	})
+
+	When("when provisioning fails", func() {
+
+		// It tests the resilience of the dynamic pool. When a TaskRun is assigned
+		// an instance from the pool and that instance fails provisioning, this test
+		// verifies that the system will attempt to launch a new instance to
+		// replace the failed one, ensuring the pool maintains its desired capacity.
+		It("should try to launch a new instance if an existing one fails", func(ctx SpecContext) {
+			// Start with one running instance in the pool
+			_, err := cloudImpl.LaunchInstance(nil, ctx, "default:preexisting-task", "multi-platform-controller", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(cloudImpl.Instances)).To(Equal(1))
+
+			// Start a user task. It should be assigned the single pre-existing instance.
+			userTask := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-dyn-pool-fail-1")
+			initialHost := userTask.Labels[AssignedHost]
+			Expect(initialHost).To(Equal("preexisting-task"))
+
+			// Fail the provision task for that instance
+			provisionTask := getProvisionTaskRun(ctx, GinkgoT(), client, userTask)
+			provisionTask.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provisionTask.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: v1.ConditionFalse,
+			})
+			Expect(client.Status().Update(ctx, provisionTask)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provisionTask.Namespace, Name: provisionTask.Name}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Delete(ctx, provisionTask)).To(Succeed())
+
+			// The user task should now be un-assigned and waiting
+			updatedUserTask := getUserTaskRun(ctx, GinkgoT(), client, "test-dyn-pool-fail-1")
+			Expect(updatedUserTask.Annotations[FailedHosts]).To(ContainSubstring(initialHost))
+			Expect(updatedUserTask.Labels[AssignedHost]).To(BeEmpty())
+
+			// Reconcile the user task again. Since the pool has capacity (max 2), it should launch a NEW instance.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: updatedUserTask.Namespace, Name: updatedUserTask.Name}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// A new instance should have been created. The user task will be requeued while it starts.
+			Expect(len(cloudImpl.Instances)).To(Equal(2)) // The old failed one plus the new one
+			finalUserTask := getUserTaskRun(ctx, GinkgoT(), client, "test-dyn-pool-fail-1")
+			// It won't be assigned a host yet, because the new instance is "starting up"
+			Expect(finalUserTask.Labels[AssignedHost]).To(BeEmpty())
+		})
+
+		// It tests the scenario where the pool is at maximum capacity and all
+		// available instances fail provisioning for a single TaskRun. The test
+		// verifies that the TaskRun will correctly be marked as failed after
+		// exhausting all options in the pool.
+		It("should fail the task run if all instances fail and the pool is full", func(ctx SpecContext) {
+			// Fill the pool to its maximum capacity (2 instances)
+			_, err := cloudImpl.LaunchInstance(nil, ctx, "default:preexisting-1", "multi-platform-controller", nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = cloudImpl.LaunchInstance(nil, ctx, "default:preexisting-2", "multi-platform-controller", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(cloudImpl.Instances)).To(Equal(2))
+
+			// Start a user task. It will be assigned one of the instances.
+			userTask := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-dyn-pool-all-fail")
+			host1 := userTask.Labels[AssignedHost]
+
+			// Fail the first provision task
+			provision1 := getProvisionTaskRun(ctx, GinkgoT(), client, userTask)
+			provision1.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provision1.Status.SetCondition(&apis.Condition{Type: apis.ConditionSucceeded, Status: v1.ConditionFalse})
+			Expect(client.Status().Update(ctx, provision1)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision1.Namespace, Name: provision1.Name}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Delete(ctx, provision1)).To(Succeed())
+
+			// Reconcile the user task. It should pick the second available instance.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userTask.Namespace, Name: userTask.Name}})
+			Expect(err).NotTo(HaveOccurred())
+			userTask = getUserTaskRun(ctx, GinkgoT(), client, "test-dyn-pool-all-fail")
+			host2 := userTask.Labels[AssignedHost]
+			Expect(host2).NotTo(Equal(host1))
+
+			// Fail the second provision task
+			provision2 := getProvisionTaskRun(ctx, GinkgoT(), client, userTask)
+			provision2.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provision2.Status.SetCondition(&apis.Condition{Type: apis.ConditionSucceeded, Status: v1.ConditionFalse})
+			Expect(client.Status().Update(ctx, provision2)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision2.Namespace, Name: provision2.Name}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The task should now have failed both hosts and, since the pool is full, it should give up.
+			userTask = getUserTaskRun(ctx, GinkgoT(), client, "test-dyn-pool-all-fail")
+			Expect(userTask.Annotations[FailedHosts]).To(ContainSubstring(host1))
+			Expect(userTask.Annotations[FailedHosts]).To(ContainSubstring(host2))
+
+			// The final reconcile should result in an error and an error secret.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userTask.Namespace, Name: userTask.Name}})
+			Expect(err).To(HaveOccurred())
+			secret := getSecret(ctx, client, userTask)
+			Expect(secret.Data["error"]).NotTo(BeEmpty())
+		})
+	})
+})

--- a/pkg/reconciler/taskrun/provision_local_test.go
+++ b/pkg/reconciler/taskrun/provision_local_test.go
@@ -31,11 +31,11 @@ var _ = Describe("Test Local Host Provisioning", func() {
 	// host "localhost" is correctly generated, and that all resources are
 	// cleaned up after the user TaskRun completes.
 	It("should allocate a local host correctly", func(ctx SpecContext) {
-		tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-local")
-		ExpectNoProvisionTaskRun(ctx, GinkgoT(), client, tr)
+		tr := runUserPipeline(ctx, client, reconciler, "test-local")
+		ExpectNoProvisionTaskRun(ctx, client, tr)
 		secret := getSecret(ctx, client, tr)
-		Expect(secret.Data["error"]).To(BeEmpty())
-		Expect(secret.Data["host"]).To(Equal([]byte("localhost")))
+		Expect(secret.Data["error"]).Should(BeEmpty())
+		Expect(secret.Data["host"]).Should(Equal([]byte("localhost")))
 
 		// Set user task as complete
 		Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).Should(Succeed())
@@ -52,6 +52,6 @@ var _ = Describe("Test Local Host Provisioning", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Verify that the secret has been cleaned up.
-		assertNoSecret(ctx, GinkgoT(), client, tr)
+		assertNoSecret(ctx, client, tr)
 	})
 })

--- a/pkg/reconciler/taskrun/provision_local_test.go
+++ b/pkg/reconciler/taskrun/provision_local_test.go
@@ -1,0 +1,57 @@
+// This file contains tests for the 'local' host provisioning strategy.
+// This strategy is the simplest: it assigns the TaskRun to run on the same
+// node as the controller itself without creating a separate
+// provisioner TaskRun. The tests ensure that the correct secret is created
+// and that cleanup is handled properly upon TaskRun completion.
+package taskrun
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Test Local Host Provisioning", func() {
+
+	var client runtimeclient.Client
+	var reconciler *ReconcileTaskRun
+
+	BeforeEach(func() {
+		client, reconciler = setupClientAndReconciler(createLocalHostConfig())
+	})
+
+	// It verifies the complete happy-path for local provisioning.
+	// The test ensures that no provisioner TaskRun is created, a secret with the
+	// host "localhost" is correctly generated, and that all resources are
+	// cleaned up after the user TaskRun completes.
+	It("should allocate a local host correctly", func(ctx SpecContext) {
+		tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-local")
+		ExpectNoProvisionTaskRun(ctx, GinkgoT(), client, tr)
+		secret := getSecret(ctx, client, tr)
+		Expect(secret.Data["error"]).To(BeEmpty())
+		Expect(secret.Data["host"]).To(Equal([]byte("localhost")))
+
+		// Set user task as complete
+		Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).Should(Succeed())
+		tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+		tr.Status.SetCondition(&apis.Condition{
+			Type:               apis.ConditionSucceeded,
+			Status:             "True",
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
+		})
+		Expect(client.Status().Update(ctx, tr)).Should(Succeed())
+
+		// Run reconciler once more to trigger cleanup
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify that the secret has been cleaned up.
+		assertNoSecret(ctx, GinkgoT(), client, tr)
+	})
+})

--- a/pkg/reconciler/taskrun/provision_static_test.go
+++ b/pkg/reconciler/taskrun/provision_static_test.go
@@ -1,0 +1,272 @@
+// This file contains tests focused exclusively on the static host
+// provisioning logic. It validates the allocation of hosts from a predefined
+// pool, concurrency management, and failure handling for these static hosts.
+package taskrun
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Test Static Host Provisioning", func() {
+
+	var client runtimeclient.Client
+	var reconciler *ReconcileTaskRun
+
+	BeforeEach(func() {
+		client, reconciler = setupClientAndReconciler(createHostConfig())
+	})
+
+	// It tests the basic happy-path of allocating a host from the static pool
+	// and verifies that the created provisioner TaskRun has the correct parameters.
+	It("should allocate a host correctly", func(ctx SpecContext) {
+		tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-static-alloc")
+		provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+		params := map[string]string{}
+		for _, i := range provision.Spec.Params {
+			params[i.Name] = i.Value.StringVal
+		}
+		Expect(params["SECRET_NAME"]).Should(Equal("multi-platform-ssh-test-static-alloc"))
+		Expect(params["TASKRUN_NAME"]).Should(Equal("test-static-alloc"))
+		Expect(params["NAMESPACE"]).Should(Equal(userNamespace))
+		Expect(params["USER"]).Should(Equal("ec2-user"))
+		Expect(params["HOST"]).Should(BeElementOf("ec2-34-227-115-211.compute-1.amazonaws.com", "ec2-54-165-44-192.compute-1.amazonaws.com"))
+	})
+
+	// It tests the scenario where all available host slots are occupied.
+	// The test ensures that a new TaskRun will wait (indicated by the
+	// 'WaitingForPlatformLabel') until a slot is freed up by a completed
+	// TaskRun, at which point it gets scheduled correctly.
+	It("should wait for concurrency slots to open up", func(ctx SpecContext) {
+		// Saturate the host pool by running tasks until all concurrency slots are used.
+		runs := []*pipelinev1.TaskRun{}
+		for i := 0; i < 8; i++ {
+			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, fmt.Sprintf("test-%d", i))
+			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
+			runs = append(runs, tr)
+		}
+		// Create one more TaskRun, which should now be forced to wait.
+		name := fmt.Sprintf("test-%d", 9)
+		createUserTaskRun(ctx, GinkgoT(), client, name, "linux/arm64")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
+		Expect(err).ShouldNot(HaveOccurred())
+		tr := getUserTaskRun(ctx, GinkgoT(), client, name)
+		Expect(tr.Labels[WaitingForPlatformLabel]).Should(Equal("linux-arm64"))
+
+		// Complete one of the running tasks to free up a slot.
+		running := runs[0]
+		running.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+		running.Status.SetCondition(&apis.Condition{
+			Type:               apis.ConditionSucceeded,
+			Status:             "True",
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
+		})
+		Expect(client.Status().Update(ctx, running)).ShouldNot(HaveOccurred())
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: running.Namespace, Name: running.Name}})
+		Expect(err).ShouldNot(HaveOccurred())
+		assertNoSecret(ctx, GinkgoT(), client, running)
+
+		// Verify that the waiting TaskRun is now allocated a host.
+		tr = getUserTaskRun(ctx, GinkgoT(), client, name)
+		Expect(tr.Labels[WaitingForPlatformLabel]).Should(BeEmpty())
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
+		Expect(err).ShouldNot(HaveOccurred())
+		tr = getUserTaskRun(ctx, GinkgoT(), client, name)
+		Expect(getProvisionTaskRun(ctx, GinkgoT(), client, tr)).ShouldNot(BeNil())
+	})
+
+	When("when provisioning fails", func() {
+
+		// It tests the reallocation logic. When a provisioner TaskRun fails for
+		// an assigned host, the test ensures that the host is marked as failed
+		// (in the 'FailedHosts' annotation) and that the system attempts to
+		// allocate a different host from the pool.
+		It("should mark the host as failed and attempt to re-allocate", func(ctx SpecContext) {
+			// Create the initial user task that needs a host.
+			userTask := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-single-failure")
+			Expect(userTask.Labels[AssignedHost]).NotTo(BeEmpty(), "A host should have been assigned initially")
+			initialHost := userTask.Labels[AssignedHost]
+
+			// Get the provision task that was created for our user task.
+			provisionTask := getProvisionTaskRun(ctx, GinkgoT(), client, userTask)
+			Expect(provisionTask).NotTo(BeNil(), "A provision task should have been created")
+
+			// Telling the system "this thing failed."
+			provisionTask.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provisionTask.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: v1.ConditionFalse, // Here's the failure!
+			})
+			Expect(client.Status().Update(ctx, provisionTask)).Should(Succeed(), "Failed to update provision task to a failed state")
+
+			// Failure and update the original user task.
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provisionTask.Namespace, Name: provisionTask.Name}})
+			Expect(err).NotTo(HaveOccurred(), "Reconciling the failed provision task should not error")
+
+			Expect(client.Delete(ctx, provisionTask)).Should(Succeed(), "Failed to delete the old provision task")
+
+			// Get the user task again and see what state it's in.
+			updatedUserTask := getUserTaskRun(ctx, GinkgoT(), client, "test-single-failure")
+			Expect(updatedUserTask.Annotations[FailedHosts]).Should(ContainSubstring(initialHost), "The failed host should be recorded")
+			Expect(updatedUserTask.Labels[AssignedHost]).Should(BeEmpty(), "The failed host should be un-assigned")
+
+			// The reconciler should try to find a NEW host.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: updatedUserTask.Namespace, Name: updatedUserTask.Name}})
+			Expect(err).NotTo(HaveOccurred(), "Re-reconciling the user task should not error")
+
+			// Verify that a new host was found.
+			finalUserTask := getUserTaskRun(ctx, GinkgoT(), client, "test-single-failure")
+			Expect(finalUserTask.Labels[AssignedHost]).NotTo(BeEmpty(), "A new host should have been assigned")
+			Expect(finalUserTask.Labels[AssignedHost]).NotTo(Equal(initialHost), "The new host should not be the same as the one that failed")
+
+			// We should have a new provision task.
+			newProvisionTask := getProvisionTaskRun(ctx, GinkgoT(), client, finalUserTask)
+			Expect(newProvisionTask).NotTo(BeNil(), "A new provision task should have been created for the new host")
+			Expect(newProvisionTask.UID).NotTo(Equal(provisionTask.UID), "The new provision task should have a different UID, indicating it's a new object")
+		})
+
+		// It tests the scenario where every available host in the static pool
+		// fails provisioning. The test ensures that after all hosts have been
+		// tried and failed, the user TaskRun is ultimately marked as failed
+		// and an error is written to its secret.
+		It("should fail the task run after all hosts have been tried", func(ctx SpecContext) {
+			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-all-fail")
+			provision1 := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+			host1 := provision1.Labels[AssignedHost]
+
+			// Fail the first host
+			provision1.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provision1.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: v1.ConditionFalse,
+			})
+			Expect(client.Status().Update(ctx, provision1)).ShouldNot(HaveOccurred())
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision1.Namespace, Name: provision1.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(client.Delete(ctx, provision1)).Should(Succeed())
+
+			// Reconcile the user task to try the next host
+			tr = getUserTaskRun(ctx, GinkgoT(), client, "test-all-fail")
+			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host1))
+			Expect(tr.Labels[AssignedHost]).Should(BeEmpty())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fail the second host
+			provision2 := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+			host2 := provision2.Labels[AssignedHost]
+			provision2.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provision2.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: v1.ConditionFalse,
+			})
+			Expect(client.Status().Update(ctx, provision2)).ShouldNot(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision2.Namespace, Name: provision2.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Check final state
+			tr = getUserTaskRun(ctx, GinkgoT(), client, "test-all-fail")
+			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host1))
+			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host2))
+			Expect(tr.Labels[AssignedHost]).Should(BeEmpty())
+
+			// Final reconcile should now fail the task run
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+			Expect(err).Should(HaveOccurred())
+
+			secret := getSecret(ctx, client, tr)
+			Expect(secret.Data["error"]).ShouldNot(BeEmpty())
+		})
+	})
+
+	When("when provisioning succeeds", func() {
+
+		// It tests a specific failure case where the provisioner TaskRun reports
+		// success, but the secret containing the SSH key and host information is
+		// never created. The test ensures the controller handles this by creating
+		// an error secret for the user TaskRun.
+		It("should create an error secret if the provision task succeeds but does not create a secret", func(ctx SpecContext) {
+			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-no-secret")
+			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+
+			provision.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			provision.Status.SetCondition(&apis.Condition{
+				Type:               apis.ConditionSucceeded,
+				Status:             "True",
+				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
+			})
+			Expect(client.Status().Update(ctx, provision)).ShouldNot(HaveOccurred())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision.Namespace, Name: provision.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+			secret := getSecret(ctx, client, tr)
+			Expect(secret.Data["error"]).ShouldNot(BeEmpty())
+		})
+
+		// It tests the end-to-end happy path, including cleanup.
+		// A user TaskRun is created, provisioned, completes successfully, and
+		// the test verifies that all related resources (secrets, provisioner TaskRuns)
+		// are properly deleted afterward.
+		It("should successfully provision and clean up", func(ctx SpecContext) {
+			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-success")
+			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
+
+			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
+
+			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			tr.Status.SetCondition(&apis.Condition{
+				Type:               apis.ConditionSucceeded,
+				Status:             "True",
+				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
+			})
+			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
+			Expect(err).ShouldNot(HaveOccurred())
+			assertNoSecret(ctx, GinkgoT(), client, tr)
+
+			list := pipelinev1.TaskRunList{}
+			err = client.List(ctx, &list)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			for idx := range list.Items {
+				i := list.Items[idx]
+				if i.Labels[TaskTypeLabel] != "" {
+					if i.Status.CompletionTime == nil {
+						endTime := time.Now().Add(time.Hour * -2)
+						i.Status.CompletionTime = &metav1.Time{Time: endTime}
+						i.Status.SetCondition(&apis.Condition{
+							Type:               apis.ConditionSucceeded,
+							Status:             "True",
+							LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: endTime}},
+						})
+						Expect(client.Status().Update(ctx, &i)).ShouldNot(HaveOccurred())
+					}
+
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: i.Namespace, Name: i.Name}})
+					Expect(err).ShouldNot(HaveOccurred())
+				}
+			}
+
+			taskExists := false
+			err = client.List(ctx, &list)
+			Expect(err).ShouldNot(HaveOccurred())
+			for _, i := range list.Items {
+				if i.Labels[TaskTypeLabel] != "" {
+					taskExists = true
+				}
+			}
+			Expect(taskExists).Should(BeFalse())
+		})
+	})
+})

--- a/pkg/reconciler/taskrun/taskrun_helpers_test.go
+++ b/pkg/reconciler/taskrun/taskrun_helpers_test.go
@@ -1,0 +1,475 @@
+// taskrun_helpers_test.go
+
+// This file contains shared helper functions, mock implementations, and setup
+// utilities used across the entire taskrun test suite. It is not a test suite
+// itself but provides the building blocks for other test files.
+
+package taskrun
+
+import (
+	"context"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"strings"
+	"time"
+
+	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"knative.dev/pkg/apis"
+)
+
+const (
+	systemNamespace = "multi-platform-controller"
+	userNamespace   = "default"
+)
+
+// setupClientAndReconciler initializes a new fake Kubernetes client and a
+// ReconcileTaskRun instance for use in tests. It pre-populates the client
+// with the provided runtime objects.
+func setupClientAndReconciler(objs []runtimeclient.Object) (runtimeclient.Client, *ReconcileTaskRun) {
+	scheme := runtime.NewScheme()
+	_ = pipelinev1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+
+	// We need to tell the fake client about the status subresource for TaskRuns
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).WithStatusSubresource(&pipelinev1.TaskRun{}).Build()
+
+	// Wrap the fake client to automatically assign UIDs on Create.
+	client := &clientWithUIDs{Client: fakeClient}
+
+	reconciler := &ReconcileTaskRun{
+		apiReader:         client,
+		client:            client,
+		scheme:            scheme,
+		eventRecorder:     &record.FakeRecorder{},
+		operatorNamespace: systemNamespace,
+		cloudProviders:    map[string]func(platform string, config map[string]string, systemnamespace string) cloud.CloudProvider{"mock": MockCloudSetup},
+		platformConfig:    map[string]PlatformConfig{},
+	}
+	return client, reconciler
+}
+
+// cloudImpl is a global mock implementation of the cloud.CloudProvider interface.
+// It allows tests to simulate cloud instance interactions without making real API calls.
+var cloudImpl MockCloud = MockCloud{Instances: map[cloud.InstanceIdentifier]MockInstance{}}
+
+// clientWithUIDs is a wrapper around a fake client that adds UIDs on Create,
+// to more closely mimic the behavior of a real Kubernetes API server where every
+// new object gets a unique identifier
+type clientWithUIDs struct {
+	runtimeclient.Client
+	uidCounter int
+}
+
+// Create intercepts the Create call and adds a UID to the object if it doesn't have one.
+func (c *clientWithUIDs) Create(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
+	metaObj, ok := obj.(metav1.Object)
+	if ok {
+		if metaObj.GetUID() == "" {
+			c.uidCounter++
+			metaObj.SetUID(types.UID(fmt.Sprintf("uid-%d", c.uidCounter)))
+		}
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+// runSuccessfulProvision simulates a successful provision TaskRun. It updates the
+// provision TaskRun's status to Succeeded, creates the corresponding secret that
+// the provisioner would have created, and then runs the reconciler to process the result.
+func runSuccessfulProvision(ctx context.Context, provision *pipelinev1.TaskRun, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun, reconciler *ReconcileTaskRun) {
+	provision.Status.CompletionTime = &metav1.Time{Time: time.Now().Add(time.Hour * -2)}
+	provision.Status.SetCondition(&apis.Condition{
+		Type:               apis.ConditionSucceeded,
+		Status:             "True",
+		LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
+	})
+	Expect(client.Status().Update(ctx, provision)).ShouldNot(HaveOccurred())
+
+	s := v1.Secret{}
+	s.Name = SecretPrefix + tr.Name
+	s.Namespace = tr.Namespace
+	s.Data = map[string][]byte{}
+	s.Data["id_rsa"] = []byte("expected")
+	s.Data["host"] = []byte("host")
+	s.Data["user-dir"] = []byte("buildir")
+	Expect(client.Create(ctx, &s)).ShouldNot(HaveOccurred())
+
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision.Namespace, Name: provision.Name}})
+	Expect(err).ShouldNot(HaveOccurred())
+	secret := getSecret(ctx, client, tr)
+	Expect(secret.Data["error"]).Should(BeEmpty())
+}
+
+// getSecret retrieves the secret associated with a given user TaskRun.
+
+func getSecret(ctx context.Context, client runtimeclient.Client, tr *pipelinev1.TaskRun) *v1.Secret {
+	name := SecretPrefix + tr.Name
+	secret := v1.Secret{}
+	Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: name}, &secret)).Should(Succeed())
+	return &secret
+}
+
+// assertNoSecret asserts that the secret for a given user TaskRun does not exist,
+// which is used to verify cleanup logic.
+func assertNoSecret(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun) {
+	name := SecretPrefix + tr.Name
+	secret := v1.Secret{}
+	err := client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: name}, &secret)
+	Expect(errors.IsNotFound(err)).Should(BeTrue())
+}
+
+// runUserPipeline encapsulates the common flow of creating a user TaskRun
+// and reconciling it until a provisioner TaskRun is created or a host is assigned.
+// This helper is used in happy-path scenarios to reduce boilerplate.
+func runUserPipeline(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, reconciler *ReconcileTaskRun, name string) *pipelinev1.TaskRun {
+	createUserTaskRun(ctx, g, client, name, "linux/arm64")
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
+	Expect(err).ShouldNot(HaveOccurred())
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
+	Expect(err).ShouldNot(HaveOccurred())
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
+	Expect(err).ShouldNot(HaveOccurred())
+	tr := getUserTaskRun(ctx, g, client, name)
+	if tr.Labels[AssignedHost] == "" {
+		Expect(tr.Annotations[CloudInstanceId]).ShouldNot(BeEmpty())
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
+		Expect(err).ShouldNot(HaveOccurred())
+		tr = getUserTaskRun(ctx, g, client, name)
+	}
+	Expect(tr.Labels[AssignedHost]).ShouldNot(BeEmpty())
+	return tr
+}
+
+// getProvisionTaskRun finds and returns the provisioner TaskRun that was created
+// on behalf of a given user TaskRun.
+func getProvisionTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun) *pipelinev1.TaskRun {
+	list := pipelinev1.TaskRunList{}
+	err := client.List(ctx, &list, &runtimeclient.ListOptions{Namespace: systemNamespace})
+	Expect(err).ShouldNot(HaveOccurred())
+	for i := range list.Items {
+		if list.Items[i].Labels[UserTaskName] == tr.Name && list.Items[i].Labels[UserTaskNamespace] == tr.Namespace {
+			return &list.Items[i]
+		}
+	}
+	Expect("could not find task").Should(BeEmpty())
+	return nil
+}
+
+// ExpectNoProvisionTaskRun asserts that no provisioner TaskRun was created for a
+// user TaskRun, which is the expected behavior for certain provisioning types like 'local'.
+func ExpectNoProvisionTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun) {
+	list := pipelinev1.TaskRunList{}
+	err := client.List(ctx, &list)
+	Expect(err).ShouldNot(HaveOccurred())
+	foundCount := 0
+	for i := range list.Items {
+		if list.Items[i].Labels[AssignedHost] == "" && list.Items[i].Labels[UserTaskName] == tr.Name {
+			foundCount++
+		}
+	}
+	Expect(foundCount).Should(BeNumerically("==", 0))
+}
+
+// getUserTaskRun retrieves a user TaskRun by its name from the default user namespace.
+func getUserTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, name string) *pipelinev1.TaskRun {
+	ret := pipelinev1.TaskRun{}
+	err := client.Get(ctx, types.NamespacedName{Namespace: userNamespace, Name: name}, &ret)
+	Expect(err).ShouldNot(HaveOccurred())
+	return &ret
+}
+
+// createUserTaskRun creates a basic user TaskRun with the specified name and platform.
+func createUserTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, name string, platform string) {
+	tr := &pipelinev1.TaskRun{}
+	tr.Namespace = userNamespace
+	tr.Name = name
+	tr.Labels = map[string]string{"tekton.dev/memberOf": "tasks"}
+	tr.Spec = pipelinev1.TaskRunSpec{
+		Params: []pipelinev1.Param{{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues(platform)}},
+	}
+	tr.Status.TaskSpec = &pipelinev1.TaskSpec{Volumes: []v1.Volume{{Name: "test", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: SecretPrefix + name}}}}}
+	Expect(client.Create(ctx, tr)).ShouldNot(HaveOccurred())
+}
+
+// createHostConfig is a factory function that returns the necessary Kubernetes
+// objects (ConfigMap, Secret) to represent a static host pool configuration.
+func createHostConfig() []runtimeclient.Object {
+	cm := createHostConfigMap()
+	sec := v1.Secret{}
+	sec.Name = "awskeys"
+	sec.Namespace = systemNamespace
+	sec.Labels = map[string]string{MultiPlatformSecretLabel: "true"}
+	return []runtimeclient.Object{&cm, &sec}
+}
+
+// createHostConfigMap creates the ConfigMap for a static host pool.
+func createHostConfigMap() v1.ConfigMap {
+	cm := v1.ConfigMap{}
+	cm.Name = HostConfig
+	cm.Namespace = systemNamespace
+	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
+	cm.Data = map[string]string{
+		"allowed-namespaces":     "default,system-.*",
+		"host.host1.address":     "ec2-54-165-44-192.compute-1.amazonaws.com",
+		"host.host1.secret":      "awskeys",
+		"host.host1.concurrency": "4",
+		"host.host1.user":        "ec2-user",
+		"host.host1.platform":    "linux/arm64",
+		"host.host2.address":     "ec2-34-227-115-211.compute-1.amazonaws.com",
+		"host.host2.secret":      "awskeys",
+		"host.host2.concurrency": "4",
+		"host.host2.user":        "ec2-user",
+		"host.host2.platform":    "linux/arm64",
+	}
+	return cm
+}
+
+// createDynamicHostConfig is a factory function for a dynamic provisioning configuration.
+func createDynamicHostConfig() []runtimeclient.Object {
+	cm := v1.ConfigMap{}
+	cm.Name = HostConfig
+	cm.Namespace = systemNamespace
+	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
+	cm.Data = map[string]string{
+		"additional-instance-tags":               "foo=bar,key=value",
+		"dynamic-platforms":                      "linux/arm64",
+		"dynamic.linux-arm64.type":               "mock",
+		"dynamic.linux-arm64.region":             "us-east-1",
+		"dynamic.linux-arm64.ami":                "ami-03d6a5256a46c9feb",
+		"dynamic.linux-arm64.instance-type":      "t4g.medium",
+		"dynamic.linux-arm64.key-name":           "sdouglas-arm-test",
+		"dynamic.linux-arm64.aws-secret":         "awsiam",
+		"dynamic.linux-arm64.ssh-secret":         "awskeys",
+		"dynamic.linux-arm64.max-instances":      "2",
+		"dynamic.linux-arm64.allocation-timeout": "2",
+	}
+	sec := v1.Secret{}
+	sec.Name = "awskeys"
+	sec.Namespace = systemNamespace
+	sec.Labels = map[string]string{MultiPlatformSecretLabel: "true"}
+	return []runtimeclient.Object{&cm, &sec}
+}
+
+// createDynamicPoolHostConfig is a factory function for a dynamic pool configuration.
+func createDynamicPoolHostConfig() []runtimeclient.Object {
+	cm := v1.ConfigMap{}
+	cm.Name = HostConfig
+	cm.Namespace = systemNamespace
+	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
+	cm.Data = map[string]string{
+		"additional-instance-tags":          "foo=bar,key=value",
+		"dynamic-pool-platforms":            "linux/arm64",
+		"dynamic.linux-arm64.type":          "mock",
+		"dynamic.linux-arm64.region":        "us-east-1",
+		"dynamic.linux-arm64.ami":           "ami-03d6a5256a46c9feb",
+		"dynamic.linux-arm64.instance-type": "t4g.medium",
+		"dynamic.linux-arm64.key-name":      "sdouglas-arm-test",
+		"dynamic.linux-arm64.aws-secret":    "awsiam",
+		"dynamic.linux-arm64.ssh-secret":    "awskeys",
+		"dynamic.linux-arm64.max-instances": "2",
+		"dynamic.linux-arm64.concurrency":   "2",
+		"dynamic.linux-arm64.max-age":       "20",
+	}
+	sec := v1.Secret{}
+	sec.Name = "awskeys"
+	sec.Namespace = systemNamespace
+	sec.Labels = map[string]string{MultiPlatformSecretLabel: "true"}
+	return []runtimeclient.Object{&cm, &sec}
+}
+
+// createLocalHostConfig is a factory function for a local provisioning configuration.
+func createLocalHostConfig() []runtimeclient.Object {
+	cm := v1.ConfigMap{}
+	cm.Name = HostConfig
+	cm.Namespace = systemNamespace
+	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
+	cm.Data = map[string]string{
+		"local-platforms": "linux/arm64",
+	}
+	return []runtimeclient.Object{&cm}
+}
+
+// MockInstance represents a simulated cloud instance for testing purposes.
+type MockInstance struct {
+	cloud.CloudVMInstance
+	taskRun  string
+	statusOK bool
+}
+
+// MockCloud is a mock implementation of the cloud.CloudProvider interface,
+// allowing tests to simulate cloud provider interactions like launching and
+// terminating instances without needing real credentials or infrastructure.
+type MockCloud struct {
+	Running           int
+	Terminated        int
+	Instances         map[cloud.InstanceIdentifier]MockInstance
+	FailGetAddress    bool
+	TimeoutGetAddress bool
+	FailGetState      bool
+	FailCleanUpVMs    bool
+}
+
+func (m *MockCloud) ListInstances(kubeClient runtimeclient.Client, ctx context.Context, instanceTag string) ([]cloud.CloudVMInstance, error) {
+	ret := []cloud.CloudVMInstance{}
+	for _, v := range m.Instances {
+		ret = append(ret, v.CloudVMInstance)
+	}
+	return ret, nil
+}
+
+func (m *MockCloud) CountInstances(kubeClient runtimeclient.Client, ctx context.Context, instanceTag string) (int, error) {
+	return m.Running, nil
+}
+
+func (m *MockCloud) SshUser() string {
+	return "root"
+}
+
+func (m *MockCloud) LaunchInstance(kubeClient runtimeclient.Client, ctx context.Context, taskRunID string, instanceTag string, additionalTags map[string]string) (cloud.InstanceIdentifier, error) {
+	m.Running++
+	// Check that taskRunID is the correct format
+	if strings.Count(taskRunID, ":") != 1 {
+		return "", fmt.Errorf("%s was not of the correct format <namespace>:<name>", taskRunID)
+	}
+	name := strings.Split(taskRunID, ":")[1]
+
+	addr := string(name) + ".host.com"
+	identifier := cloud.InstanceIdentifier(name)
+	newInstance := MockInstance{
+		CloudVMInstance: cloud.CloudVMInstance{InstanceId: identifier, StartTime: time.Now(), Address: addr},
+		taskRun:         string(name) + " task run",
+		statusOK:        true,
+	}
+	m.Instances[identifier] = newInstance
+	return identifier, nil
+}
+
+func (m *MockCloud) TerminateInstance(kubeClient runtimeclient.Client, ctx context.Context, instance cloud.InstanceIdentifier) error {
+	m.Running--
+	m.Terminated++
+	delete(m.Instances, instance)
+	return nil
+}
+
+func (m *MockCloud) GetInstanceAddress(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
+	if m.FailGetAddress {
+		return "", fmt.Errorf("failed")
+	} else if m.TimeoutGetAddress {
+		return "", nil
+	}
+	addr := m.Instances[instanceId].Address
+	if addr == "" {
+		addr = string(instanceId) + ".host.com"
+		instance := m.Instances[instanceId]
+		instance.Address = addr
+		m.Instances[instanceId] = instance
+	}
+	return addr, nil
+}
+
+func (m *MockCloud) GetState(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (cloud.VMState, error) {
+	if m.FailGetState {
+		return "", fmt.Errorf("failed")
+	}
+
+	instance, ok := m.Instances[instanceId]
+	if !ok {
+		return "", nil
+	}
+	if !instance.statusOK {
+		return cloud.FailedState, nil
+	}
+	return cloud.OKState, nil
+}
+
+// In this implementation of the function, the MockInstance's taskRun value is compared to to the keys in existingTaskRuns for
+// a speedier return.
+func (m *MockCloud) CleanUpVms(ctx context.Context, kubeClient runtimeclient.Client, existingTaskRuns map[string][]string) error {
+	if m.FailCleanUpVMs {
+		return fmt.Errorf("failed")
+	}
+
+	var instancesToDelete []string
+	for k, v := range m.Instances {
+		_, ok := existingTaskRuns[v.taskRun]
+		if !ok {
+			instancesToDelete = append(instancesToDelete, string(k))
+		}
+	}
+
+	for _, instance := range instancesToDelete {
+		m.Running--
+		m.Terminated++
+		delete(m.Instances, cloud.InstanceIdentifier(instance))
+	}
+
+	return nil
+}
+
+func MockCloudSetup(platform string, data map[string]string, systemnamespace string) cloud.CloudProvider {
+	return &cloudImpl
+}
+
+// ConflictingClient simulates conflict errors for testing
+type ConflictingClient struct {
+	runtimeclient.Client
+	ConflictCount int
+	callCount     int
+}
+
+func (c *ConflictingClient) Update(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+	c.callCount++
+	if c.callCount <= c.ConflictCount {
+		// hardcoded gvk is not perfect but i dunno how to avoid that :(
+		return errors.NewConflict(schema.GroupResource{Group: "tekton.dev", Resource: "taskruns"}, "test", fmt.Errorf("conflict"))
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *ConflictingClient) Status() runtimeclient.StatusWriter {
+	return &ConflictingStatusWriter{
+		StatusWriter:  c.Client.Status(),
+		ConflictCount: c.ConflictCount,
+		callCount:     &c.callCount,
+		client:        c.Client,
+	}
+}
+
+type ConflictingStatusWriter struct {
+	runtimeclient.StatusWriter
+	ConflictCount int
+	callCount     *int
+	client        runtimeclient.Client
+}
+
+func (c *ConflictingStatusWriter) Update(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.SubResourceUpdateOption) error {
+	*c.callCount++
+	if *c.callCount <= c.ConflictCount {
+		return errors.NewConflict(schema.GroupResource{Group: "tekton.dev", Resource: "taskruns"}, "test", fmt.Errorf("conflict"))
+	}
+	return c.client.Status().Update(ctx, obj, opts...)
+}
+
+// ErrorClient simulates non-conflict errors for testing
+type ErrorClient struct {
+	runtimeclient.Client
+	Error error
+}
+
+func (c *ErrorClient) Update(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+	return c.Error
+}

--- a/pkg/reconciler/taskrun/taskrun_suite_test.go
+++ b/pkg/reconciler/taskrun/taskrun_suite_test.go
@@ -1,4 +1,4 @@
-package taskrun_test
+package taskrun
 
 import (
 	"testing"

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1,134 +1,53 @@
+// This file contains tests for the general functionality of the TaskRun reconciler.
+// It covers logic that is not specific to any single provisioning method, such as
+// configuration parsing for all types, platform extraction from TaskRun parameters,
+// basic failure modes, and the API client's retry mechanisms.
 package taskrun
 
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
-
-	"github.com/konflux-ci/multi-platform-controller/pkg/cloud"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
-	"knative.dev/pkg/apis"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	systemNamespace = "multi-platform-controller"
-	userNamespace   = "default"
-)
+var _ = Describe("TaskRun Reconciler General Tests", func() {
 
-var cloudImpl MockCloud = MockCloud{Instances: map[cloud.InstanceIdentifier]MockInstance{}}
-
-// clientWithUIDs is a wrapper around a fake client that adds UIDs on Create,
-// to more closely mimic the behavior of a real Kubernetes API server.
-type clientWithUIDs struct {
-	runtimeclient.Client
-	uidCounter int
-}
-
-// Create intercepts the Create call and adds a UID to the object if it doesn't have one.
-func (c *clientWithUIDs) Create(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
-	metaObj, ok := obj.(metav1.Object)
-	if ok {
-		if metaObj.GetUID() == "" {
-			c.uidCounter++
-			metaObj.SetUID(types.UID(fmt.Sprintf("uid-%d", c.uidCounter)))
-		}
-	}
-	return c.Client.Create(ctx, obj, opts...)
-}
-
-func setupClientAndReconciler(objs []runtimeclient.Object) (runtimeclient.Client, *ReconcileTaskRun) {
-	scheme := runtime.NewScheme()
-	_ = pipelinev1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-
-	// We need to tell the fake client about the status subresource for TaskRuns
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).WithStatusSubresource(&pipelinev1.TaskRun{}).Build()
-
-	// Wrap the fake client to automatically assign UIDs on Create.
-	client := &clientWithUIDs{Client: fakeClient}
-
-	reconciler := &ReconcileTaskRun{
-		apiReader:         client,
-		client:            client,
-		scheme:            scheme,
-		eventRecorder:     &record.FakeRecorder{},
-		operatorNamespace: systemNamespace,
-		cloudProviders:    map[string]func(platform string, config map[string]string, systemnamespace string) cloud.CloudProvider{"mock": MockCloudSetup},
-		platformConfig:    map[string]PlatformConfig{},
-	}
-	return client, reconciler
-}
-
-var _ = Describe("TaskRun Reconciler Tests", func() {
+	// This section verifies that the reconciler can correctly parse the main
+	// ConfigMap for all supported provisioning types.
 	Describe("Test Config Map Parsing", func() {
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			_, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-
-		It("should parse the ConfigMap correctly", func(ctx SpecContext) {
+		It("should parse the static host ConfigMap correctly", func(ctx SpecContext) {
+			_, reconciler := setupClientAndReconciler(createHostConfig())
 			configIface, err := reconciler.readConfiguration(ctx, "linux/arm64", userNamespace)
 			config := configIface.(HostPool)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(config.hosts)).To(Equal(2))
 			Expect(config.hosts["host1"].Platform).Should(Equal("linux/arm64"))
 		})
-	})
 
-	Describe("Test Config Map Parsing For Local", func() {
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			_, reconciler = setupClientAndReconciler(createLocalHostConfig())
-		})
-
-		It("should parse the ConfigMap for local correctly", func(ctx SpecContext) {
+		It("should parse the local host ConfigMap correctly", func(ctx SpecContext) {
+			_, reconciler := setupClientAndReconciler(createLocalHostConfig())
 			configIface, err := reconciler.readConfiguration(ctx, "linux/arm64", userNamespace)
 			Expect(configIface).To(BeAssignableToTypeOf(Local{}))
 			Expect(err).ToNot(HaveOccurred())
 		})
-	})
 
-	Describe("Test Config Map Parsing For Dynamic", func() {
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			_, reconciler = setupClientAndReconciler(createDynamicHostConfig())
-		})
-
-		It("should parse the ConfigMap for dynamic correctly", func(ctx SpecContext) {
+		It("should parse the dynamic host ConfigMap correctly", func(ctx SpecContext) {
+			_, reconciler := setupClientAndReconciler(createDynamicHostConfig())
 			configIface, err := reconciler.readConfiguration(ctx, "linux/arm64", userNamespace)
 			config := configIface.(DynamicResolver)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.additionalInstanceTags).Should(HaveKeyWithValue("foo", "bar"))
 			Expect(config.additionalInstanceTags).Should(HaveKeyWithValue("key", "value"))
 		})
-	})
 
-	Describe("Test Config Map Parsing For Dynamic Pool", func() {
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			_, reconciler = setupClientAndReconciler(createDynamicPoolHostConfig())
-		})
-
-		It("should parse the ConfigMap for dynamic pool correctly", func(ctx SpecContext) {
+		It("should parse the dynamic pool ConfigMap correctly", func(ctx SpecContext) {
+			_, reconciler := setupClientAndReconciler(createDynamicPoolHostConfig())
 			configIface, err := reconciler.readConfiguration(ctx, "linux/arm64", userNamespace)
 			config := configIface.(DynamicHostPool)
 			Expect(err).ToNot(HaveOccurred())
@@ -137,6 +56,8 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 		})
 	})
 
+	// This section tests the utility function responsible for extracting the
+	// target platform from a TaskRun's parameters.
 	Describe("Test extractPlatform function", func() {
 		It("should extract platform from TaskRun parameters successfully", func() {
 			tr := &pipelinev1.TaskRun{
@@ -147,57 +68,9 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 				},
 			}
 
-			Expect(extractPlatform(tr)).To(Equal("linux/amd64"))
-		})
-
-		It("should extract platform from TaskRun with multiple parameters", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/arm64")},
-						{Name: "ANOTHER_PARAM", Value: *pipelinev1.NewStructuredValues("another_value")},
-					},
-				},
-			}
-
-			Expect(extractPlatform(tr)).To(Equal("linux/arm64"))
-		})
-
-		It("should return first occurrence when multiple PlatformParam parameters exist", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/amd64")},
-						{Name: "MIDDLE_PARAM", Value: *pipelinev1.NewStructuredValues("middle_value")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/arm64")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/s390x")},
-					},
-				},
-			}
-
-			Expect(extractPlatform(tr)).To(Equal("linux/amd64")) // Should return the first occurrence
-		})
-
-		It("should return error when TaskRun has nil parameters", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: nil,
-				},
-			}
-
-			Expect(extractPlatform(tr)).Error().To(MatchError(errFailedToDeterminePlatform))
-		})
-
-		It("should return error when TaskRun has no parameters", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{},
-				},
-			}
-
-			Expect(extractPlatform(tr)).Error().To(MatchError(errFailedToDeterminePlatform))
+			platform, err := extractPlatform(tr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(platform).To(Equal("linux/amd64"))
 		})
 
 		It("should return error when PlatformParam parameter is missing", func() {
@@ -205,670 +78,50 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 				Spec: pipelinev1.TaskRunSpec{
 					Params: []pipelinev1.Param{
 						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-						{Name: "ANOTHER_PARAM", Value: *pipelinev1.NewStructuredValues("another_value")},
 					},
 				},
 			}
 
-			Expect(extractPlatform(tr)).Error().To(MatchError(errFailedToDeterminePlatform))
+			_, err := extractPlatform(tr)
+			Expect(err).To(MatchError(errFailedToDeterminePlatform))
 		})
 	})
 
-	Describe("Test Allocate Host", func() {
+	// This section tests the controller's behavior in edge cases where no suitable
+	// hosts can be found for a TaskRun.
+	Describe("Test reconciler behavior when no hosts are configured", func() {
 		var client runtimeclient.Client
 		var reconciler *ReconcileTaskRun
 
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-
-		It("should allocate a host correctly", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			params := map[string]string{}
-			for _, i := range provision.Spec.Params {
-				params[i.Name] = i.Value.StringVal
-			}
-			Expect(params["SECRET_NAME"]).To(Equal("multi-platform-ssh-test"))
-			Expect(params["TASKRUN_NAME"]).To(Equal("test"))
-			Expect(params["NAMESPACE"]).To(Equal(userNamespace))
-			Expect(params["USER"]).To(Equal("ec2-user"))
-			Expect(params["HOST"]).Should(BeElementOf("ec2-34-227-115-211.compute-1.amazonaws.com", "ec2-54-165-44-192.compute-1.amazonaws.com"))
-		})
-	})
-
-	Describe("Test Allocate Cloud Host", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
-		})
-
-		It("should allocate a cloud host correctly", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			params := map[string]string{}
-			for _, i := range provision.Spec.Params {
-				params[i.Name] = i.Value.StringVal
-			}
-			Expect(params["SECRET_NAME"]).To(Equal("multi-platform-ssh-test"))
-			Expect(params["TASKRUN_NAME"]).To(Equal("test"))
-			Expect(params["NAMESPACE"]).To(Equal(userNamespace))
-			Expect(params["USER"]).To(Equal("root"))
-			Expect(params["HOST"]).Should(Equal("test.host.com"))
-
-			_, ok := cloudImpl.Instances[("test")]
-			Expect(ok).Should(Equal(true))
-			Expect(cloudImpl.Instances[("test")].Address).Should(Equal("test.host.com"))
-			Expect(cloudImpl.Instances[("test")].taskRun).Should(Equal("test task run"))
-
-			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
-
-			Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).ShouldNot(HaveOccurred())
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-			})
-			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			_, ok = cloudImpl.Instances[("multi-platform-builder-test")]
-			Expect(ok).Should(Equal(false))
-		})
-	})
-
-	Describe("Test Allocate Local Host", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createLocalHostConfig())
-		})
-
-		It("should allocate a local host correctly", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			ExpectNoProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			secret := getSecret(ctx, client, tr)
-			Expect(secret.Data["error"]).To(BeEmpty())
-			Expect(secret.Data["host"]).To(Equal([]byte("localhost")))
-
-			// Set user task as complete
-			Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).Should(Succeed())
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-			})
-			Expect(client.Status().Update(ctx, tr)).Should(Succeed())
-
-			// Run reconciler once more to trigger cleanup
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			assertNoSecret(ctx, GinkgoT(), client, tr)
-		})
-	})
-
-	Describe("Test Change Host Config", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
-		})
-
-		It("should update the host configuration correctly", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			params := map[string]string{}
-			for _, i := range provision.Spec.Params {
-				params[i.Name] = i.Value.StringVal
-			}
-
-			Expect(params["SECRET_NAME"]).To(Equal("multi-platform-ssh-test"))
-			Expect(params["TASKRUN_NAME"]).To(Equal("test"))
-			Expect(params["NAMESPACE"]).To(Equal(userNamespace))
-			Expect(params["USER"]).To(Equal("root"))
-			Expect(params["HOST"]).To(Equal("test.host.com"))
-
-			_, ok := cloudImpl.Instances[("test")]
-			Expect(ok).Should(Equal(true))
-			Expect(cloudImpl.Instances[("test")].Address).Should(Equal("test.host.com"))
-			Expect(cloudImpl.Instances[("test")].taskRun).Should(Equal("test task run"))
-
-			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
-
-			Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).To(Succeed())
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-			})
-			Expect(client.Status().Update(ctx, tr)).To(Succeed())
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ToNot(HaveOccurred())
-
-			_, ok = cloudImpl.Instances[("multi-platform-builder-test")]
-			Expect(ok).Should(Equal(false))
-
-			// Now change the config map
-			trl := pipelinev1.TaskRunList{}
-			Expect(client.List(ctx, &trl)).To(Succeed())
-			for i := range trl.Items {
-				Expect(client.Delete(ctx, &trl.Items[i])).To(Succeed())
-			}
-
-			vm := createHostConfigMap()
-
-			cm := v1.ConfigMap{}
-			Expect(client.Get(ctx, types.NamespacedName{Namespace: systemNamespace, Name: HostConfig}, &cm)).To(Succeed())
-			cm.Data = vm.Data
-			Expect(client.Update(ctx, &cm)).To(Succeed())
-
-			tr = runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision = getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			params = map[string]string{}
-			for _, i := range provision.Spec.Params {
-				params[i.Name] = i.Value.StringVal
-			}
-
-			Expect(params["SECRET_NAME"]).To(Equal("multi-platform-ssh-test"))
-			Expect(params["TASKRUN_NAME"]).To(Equal("test"))
-			Expect(params["NAMESPACE"]).To(Equal(userNamespace))
-			Expect(params["USER"]).To(Equal("ec2-user"))
-			Expect(params["HOST"]).To(BeElementOf("ec2-34-227-115-211.compute-1.amazonaws.com", "ec2-54-165-44-192.compute-1.amazonaws.com"))
-
-			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
-
-			Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).To(Succeed())
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-			})
-			Expect(client.Status().Update(ctx, tr)).To(Succeed())
-
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Describe("Test Allocate Cloud Host Instance Failure", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
-			cloudImpl.FailGetAddress = true
-		})
-
-		AfterEach(func() {
-			cloudImpl.FailGetAddress = false
-		})
-
-		It("should handle instance failure correctly", func(ctx SpecContext) {
-			createUserTaskRun(ctx, GinkgoT(), client, "test", "linux/arm64")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).To(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-			tr := getUserTaskRun(ctx, GinkgoT(), client, "test")
-			Expect(tr.Labels[AssignedHost]).To(BeEmpty())
-			Expect(cloudImpl.Running).Should(Equal(0))
-			_, ok := cloudImpl.Instances[("multi-platform-builder-test")]
-			Expect(ok).Should(Equal(false))
-		})
-	})
-
-	Describe("Test Allocate Cloud Host Instance Timeout", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
-			cloudImpl.TimeoutGetAddress = true
-		})
-
-		AfterEach(func() {
-			cloudImpl.TimeoutGetAddress = false
-		})
-
-		It("should handle instance timeout correctly", func(ctx SpecContext) {
-			createUserTaskRun(ctx, GinkgoT(), client, "test", "linux/arm64")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-			time.Sleep(time.Second)
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-			time.Sleep(time.Second * 2)
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).To(HaveOccurred())
-			tr := getUserTaskRun(ctx, GinkgoT(), client, "test")
-			Expect(tr.Labels[AssignedHost]).To(BeEmpty())
-			Expect(cloudImpl.Running).Should(Equal(0))
-			_, ok := cloudImpl.Instances[("multi-platform-builder-test")]
-			Expect(ok).Should(Equal(false))
-		})
-	})
-
-	Describe("Test Allocate Cloud Host Provision Failure In Middle", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createDynamicHostConfig())
-			createUserTaskRun(ctx, GinkgoT(), client, "test", "linux/arm64")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should handle provision failure in the middle correctly", func(ctx SpecContext) {
-			tr := getUserTaskRun(ctx, GinkgoT(), client, "test")
-			if tr.Labels[AssignedHost] == "" {
-				Expect(tr.Annotations[CloudInstanceId]).ToNot(BeEmpty())
-			}
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "False",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-			})
-			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			_, ok := cloudImpl.Instances[("multi-platform-builder-test")]
-			Expect(ok).Should(Equal(false))
-			Expect(cloudImpl.Running).Should(Equal(0))
-		})
-	})
-
-	Describe("Test Allocate Cloud Host With Dynamic Pool", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func() {
-			client, reconciler = setupClientAndReconciler(createDynamicPoolHostConfig())
-		})
-
-		It("should allocate a cloud host with dynamic pool correctly", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			params := map[string]string{}
-			for _, i := range provision.Spec.Params {
-				params[i.Name] = i.Value.StringVal
-			}
-			Expect(params["SECRET_NAME"]).To(Equal("multi-platform-ssh-test"))
-			Expect(params["TASKRUN_NAME"]).To(Equal("test"))
-			Expect(params["NAMESPACE"]).To(Equal(userNamespace))
-			Expect(params["USER"]).To(Equal("root"))
-			Expect(params["HOST"]).Should(ContainSubstring(".host.com"))
-
-			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
-
-			Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, tr)).ShouldNot(HaveOccurred())
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-			})
-			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			Expect(len(cloudImpl.Instances)).Should(Equal(1))
-		})
-	})
-
-	Describe("Test Provision Failure Scenarios", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-
-		It("should mark the host as failed and attempt to re-allocate", func(ctx SpecContext) {
-			// ARRANGE: Set up the world
-			// 1. Create the initial user task that needs a host.
-			userTask := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-single-failure")
-			Expect(userTask.Labels[AssignedHost]).NotTo(BeEmpty(), "A host should have been assigned initially")
-			initialHost := userTask.Labels[AssignedHost]
-
-			// 2. Get the provision task that was created for our user task.
-			provisionTask := getProvisionTaskRun(ctx, GinkgoT(), client, userTask)
-			Expect(provisionTask).NotTo(BeNil(), "A provision task should have been created")
-
-			// ACT: This is the magic. We manually make the provision task fail.
-			// We're not running it; we're just telling the system "this thing failed."
-			provisionTask.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			provisionTask.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: v1.ConditionFalse, // Here's the failure!
-			})
-			Expect(client.Status().Update(ctx, provisionTask)).To(Succeed(), "Failed to update provision task to a failed state")
-
-			// 3. Now, we reconcile the FAILED provision task. The reconciler should see this
-			// failure and update the original user task.
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provisionTask.Namespace, Name: provisionTask.Name}})
-			Expect(err).NotTo(HaveOccurred(), "Reconciling the failed provision task should not error")
-
-			// HERSCHEL'S FIX: Delete the old, failed provision task so a new one can be created.
-			Expect(client.Delete(ctx, provisionTask)).To(Succeed(), "Failed to delete the old provision task")
-
-			// ASSERT: Check the consequences of the failure.
-			// 4. Get the user task again and see what state it's in.
-			updatedUserTask := getUserTaskRun(ctx, GinkgoT(), client, "test-single-failure")
-			Expect(updatedUserTask.Annotations[FailedHosts]).To(ContainSubstring(initialHost), "The failed host should be recorded")
-			Expect(updatedUserTask.Labels[AssignedHost]).To(BeEmpty(), "The failed host should be un-assigned")
-
-			// ACT AGAIN: Reconcile the user task one more time. Now that the old host has failed,
-			// the reconciler should try to find a NEW host.
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: updatedUserTask.Namespace, Name: updatedUserTask.Name}})
-			Expect(err).NotTo(HaveOccurred(), "Re-reconciling the user task should not error")
-
-			// ASSERT AGAIN: Verify that a new host was found.
-			finalUserTask := getUserTaskRun(ctx, GinkgoT(), client, "test-single-failure")
-			Expect(finalUserTask.Labels[AssignedHost]).NotTo(BeEmpty(), "A new host should have been assigned")
-			Expect(finalUserTask.Labels[AssignedHost]).NotTo(Equal(initialHost), "The new host should not be the same as the one that failed")
-
-			// And we should have a *new* provision task.
-			newProvisionTask := getProvisionTaskRun(ctx, GinkgoT(), client, finalUserTask)
-			Expect(newProvisionTask).NotTo(BeNil(), "A new provision task should have been created for the new host")
-			// The name might be the same due to deterministic generation, but the UID proves it's a new object.
-			Expect(newProvisionTask.UID).NotTo(Equal(provisionTask.UID), "The new provision task should have a different UID, indicating it's a new object")
-		})
-
-		It("should fail the task run after all hosts have been tried", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test-all-fail")
-			provision1 := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			host1 := provision1.Labels[AssignedHost]
-
-			// Fail the first host
-			provision1.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			provision1.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: v1.ConditionFalse,
-			})
-			Expect(client.Status().Update(ctx, provision1)).ShouldNot(HaveOccurred())
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision1.Namespace, Name: provision1.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(client.Delete(ctx, provision1)).To(Succeed())
-
-			// Reconcile the user task to try the next host
-			tr = getUserTaskRun(ctx, GinkgoT(), client, "test-all-fail")
-			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host1))
-			Expect(tr.Labels[AssignedHost]).To(BeEmpty())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// Fail the second host
-			provision2 := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			host2 := provision2.Labels[AssignedHost]
-			provision2.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			provision2.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: v1.ConditionFalse,
-			})
-			Expect(client.Status().Update(ctx, provision2)).ShouldNot(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision2.Namespace, Name: provision2.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// Check final state
-			tr = getUserTaskRun(ctx, GinkgoT(), client, "test-all-fail")
-			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host1))
-			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host2))
-			Expect(tr.Labels[AssignedHost]).Should(BeEmpty())
-
-			// Final reconcile should now fail the task run
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).Should(HaveOccurred())
-
-			secret := getSecret(ctx, client, tr)
-			Expect(secret.Data["error"]).ToNot(BeEmpty())
-		})
-	})
-
-	Describe("Test Provision Failure", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-
-		It("should fail after all hosts have been tried", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision1 := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			host1 := provision1.Labels[AssignedHost]
-
-			// Fail the first host
-			provision1.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			provision1.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: v1.ConditionFalse,
-			})
-			Expect(client.Status().Update(ctx, provision1)).ShouldNot(HaveOccurred())
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision1.Namespace, Name: provision1.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(client.Delete(ctx, provision1)).To(Succeed())
-
-			// Reconcile the user task to try the next host
-			tr = getUserTaskRun(ctx, GinkgoT(), client, "test")
-			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host1))
-			Expect(tr.Labels[AssignedHost]).To(BeEmpty())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// Fail the second host
-			provision2 := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-			host2 := provision2.Labels[AssignedHost]
-			provision2.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			provision2.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: v1.ConditionFalse,
-			})
-			Expect(client.Status().Update(ctx, provision2)).ShouldNot(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision2.Namespace, Name: provision2.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// Check final state
-			tr = getUserTaskRun(ctx, GinkgoT(), client, "test")
-			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host1))
-			Expect(tr.Annotations[FailedHosts]).Should(ContainSubstring(host2))
-			Expect(tr.Labels[AssignedHost]).Should(BeEmpty())
-
-			// Final reconcile should now fail the task run
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).Should(HaveOccurred())
-
-			secret := getSecret(ctx, client, tr)
-			Expect(secret.Data["error"]).ToNot(BeEmpty())
-		})
-	})
-
-	Describe("Test Provision Success But No Secret", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-		It("should create an error secret if provision succeeds but secret is missing", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-
-			provision.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			provision.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
-			})
-			Expect(client.Status().Update(ctx, provision)).ShouldNot(HaveOccurred())
-
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision.Namespace, Name: provision.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-			secret := getSecret(ctx, client, tr)
-			Expect(secret.Data["error"]).ToNot(BeEmpty())
-		})
-	})
-
-	Describe("Test Provision Success", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-		It("should successfully provision and clean up", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, "test")
-			provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-
-			runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
-
-			tr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			tr.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
-			})
-			Expect(client.Status().Update(ctx, tr)).ShouldNot(HaveOccurred())
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-			assertNoSecret(ctx, GinkgoT(), client, tr)
-
-			list := pipelinev1.TaskRunList{}
-			err = client.List(ctx, &list)
-			Expect(err).ToNot(HaveOccurred())
-
-			for idx := range list.Items {
-				i := list.Items[idx]
-				if i.Labels[TaskTypeLabel] != "" {
-					if i.Status.CompletionTime == nil {
-						endTime := time.Now().Add(time.Hour * -2)
-						i.Status.CompletionTime = &metav1.Time{Time: endTime}
-						i.Status.SetCondition(&apis.Condition{
-							Type:               apis.ConditionSucceeded,
-							Status:             "True",
-							LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: endTime}},
-						})
-						Expect(client.Status().Update(ctx, &i)).ShouldNot(HaveOccurred())
-					}
-
-					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: i.Namespace, Name: i.Name}})
-					Expect(err).ShouldNot(HaveOccurred())
-				}
-			}
-
-			taskExists := false
-			err = client.List(ctx, &list)
-			Expect(err).ToNot(HaveOccurred())
-			for _, i := range list.Items {
-				if i.Labels[TaskTypeLabel] != "" {
-					taskExists = true
-				}
-			}
-			Expect(taskExists).To(BeFalse())
-		})
-	})
-
-	Describe("Test Wait For Concurrency", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
-		It("should wait for concurrency slots to open up", func(ctx SpecContext) {
-			runs := []*pipelinev1.TaskRun{}
-			for i := 0; i < 8; i++ {
-				tr := runUserPipeline(ctx, GinkgoT(), client, reconciler, fmt.Sprintf("test-%d", i))
-				provision := getProvisionTaskRun(ctx, GinkgoT(), client, tr)
-				runSuccessfulProvision(ctx, provision, GinkgoT(), client, tr, reconciler)
-				runs = append(runs, tr)
-			}
-			name := fmt.Sprintf("test-%d", 9)
-			createUserTaskRun(ctx, GinkgoT(), client, name, "linux/arm64")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
-			Expect(err).ToNot(HaveOccurred())
-			tr := getUserTaskRun(ctx, GinkgoT(), client, name)
-			Expect(tr.Labels[WaitingForPlatformLabel]).To(Equal("linux-arm64"))
-
-			running := runs[0]
-			running.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-			running.Status.SetCondition(&apis.Condition{
-				Type:               apis.ConditionSucceeded,
-				Status:             "True",
-				LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now()}},
-			})
-			Expect(client.Status().Update(ctx, running)).ShouldNot(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: running.Namespace, Name: running.Name}})
-			Expect(err).ShouldNot(HaveOccurred())
-			assertNoSecret(ctx, GinkgoT(), client, running)
-
-			tr = getUserTaskRun(ctx, GinkgoT(), client, name)
-			Expect(tr.Labels[WaitingForPlatformLabel]).To(BeEmpty())
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
-			Expect(err).ToNot(HaveOccurred())
-			tr = getUserTaskRun(ctx, GinkgoT(), client, name)
-			Expect(getProvisionTaskRun(ctx, GinkgoT(), client, tr)).ToNot(BeNil())
-		})
-	})
-
-	Describe("Test No Host Config", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler([]runtimeclient.Object{})
-		})
+		// It verifies that if no host ConfigMap exists at all, the TaskRun
+		// is immediately failed with an error secret.
 		It("should create an error secret if no host config exists", func(ctx SpecContext) {
-			createUserTaskRun(ctx, GinkgoT(), client, "test", "linux/arm64")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
+			client, reconciler = setupClientAndReconciler([]runtimeclient.Object{})
+			createUserTaskRun(ctx, GinkgoT(), client, "test-no-config", "linux/arm64")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-no-config"}})
 			Expect(err).ToNot(HaveOccurred())
-			tr := getUserTaskRun(ctx, GinkgoT(), client, "test")
+			tr := getUserTaskRun(ctx, GinkgoT(), client, "test-no-config")
 
 			secret := getSecret(ctx, client, tr)
 			Expect(secret.Data["error"]).ToNot(BeEmpty())
 		})
-	})
 
-	Describe("Test No Host With Our Platform", func() {
-		var client runtimeclient.Client
-		var reconciler *ReconcileTaskRun
-
-		BeforeEach(func(ctx SpecContext) {
-			client, reconciler = setupClientAndReconciler(createHostConfig())
-		})
+		// It verifies that if a host config exists but contains no hosts for the
+		// requested platform, the TaskRun is failed with an error secret.
 		It("should create an error secret if no host with the requested platform exists", func(ctx SpecContext) {
-			createUserTaskRun(ctx, GinkgoT(), client, "test", "powerpc")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test"}})
+			client, reconciler = setupClientAndReconciler(createHostConfig())
+			createUserTaskRun(ctx, GinkgoT(), client, "test-no-platform", "powerpc")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-no-platform"}})
 			Expect(err).To(HaveOccurred())
-			tr := getUserTaskRun(ctx, GinkgoT(), client, "test")
+			tr := getUserTaskRun(ctx, GinkgoT(), client, "test-no-platform")
 
 			secret := getSecret(ctx, client, tr)
 			Expect(secret.Data["error"]).ToNot(BeEmpty())
 		})
 	})
 
+	// This section tests the UpdateTaskRunWithRetry function, which provides
+	// resiliency against optimistic locking conflicts when updating TaskRun objects.
 	Describe("Test UpdateTaskRunWithRetry function", func() {
 		var client runtimeclient.Client
 		var tr *pipelinev1.TaskRun
@@ -916,6 +169,9 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 			Expect(updated.Finalizers).To(ContainElements("existing-finalizer", "new-finalizer"))
 		})
 
+		// It verifies that the retry logic can successfully handle and merge
+		// changes after a simulated conflict error, ensuring that concurrent
+		// updates do not cause data loss.
 		It("should handle conflict errors with retry and merge", func(ctx SpecContext) {
 			// Create a conflicting client that will cause conflicts
 			conflictingClient := &ConflictingClient{
@@ -944,6 +200,9 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 			Expect(updated.Finalizers).To(ContainElement(PipelineFinalizer))
 		})
 
+		// It simulates a real-world race condition where an external actor modifies
+		// the TaskRun while our controller is processing it. The test verifies
+		// that our changes are correctly merged with the external ones upon retry.
 		It("should merge labels and annotations correctly after conflict", func(ctx SpecContext) {
 			// First, update the TaskRun externally to simulate concurrent modification
 			external := &pipelinev1.TaskRun{}
@@ -980,6 +239,8 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 			Expect(updated.Finalizers).To(ConsistOf("existing-finalizer", PipelineFinalizer, "external-finalizer"))
 		})
 
+		// It tests that the update function does not panic or error when the
+		// TaskRun's label or annotation maps are initially nil.
 		It("should handle nil maps gracefully", func(ctx SpecContext) {
 			// Create TaskRun with nil maps
 			nilTr := &pipelinev1.TaskRun{
@@ -1011,6 +272,8 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 			Expect(updated.Finalizers).To(ContainElement(PipelineFinalizer))
 		})
 
+		// It ensures that the retry loop exits immediately for errors that are
+		// not optimistic locking conflicts.
 		It("should fail immediately on non-conflict errors", func(ctx SpecContext) {
 			// Create a client that returns non-conflict errors
 			errorClient := &ErrorClient{
@@ -1025,6 +288,8 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 			Expect(err.Error()).To(ContainSubstring("some other error"))
 		})
 
+		// It verifies that the function gives up after a maximum number of retries
+		// to prevent an infinite loop in the case of persistent conflicts.
 		It("should fail after max retries on persistent conflicts", func(ctx SpecContext) {
 			// Create a client that always returns conflicts
 			conflictingClient := &ConflictingClient{
@@ -1038,365 +303,5 @@ var _ = Describe("TaskRun Reconciler Tests", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
 })
-
-func runSuccessfulProvision(ctx context.Context, provision *pipelinev1.TaskRun, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun, reconciler *ReconcileTaskRun) {
-	provision.Status.CompletionTime = &metav1.Time{Time: time.Now().Add(time.Hour * -2)}
-	provision.Status.SetCondition(&apis.Condition{
-		Type:               apis.ConditionSucceeded,
-		Status:             "True",
-		LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
-	})
-	Expect(client.Status().Update(ctx, provision)).ShouldNot(HaveOccurred())
-
-	s := v1.Secret{}
-	s.Name = SecretPrefix + tr.Name
-	s.Namespace = tr.Namespace
-	s.Data = map[string][]byte{}
-	s.Data["id_rsa"] = []byte("expected")
-	s.Data["host"] = []byte("host")
-	s.Data["user-dir"] = []byte("buildir")
-	Expect(client.Create(ctx, &s)).ShouldNot(HaveOccurred())
-
-	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision.Namespace, Name: provision.Name}})
-	Expect(err).ShouldNot(HaveOccurred())
-	secret := getSecret(ctx, client, tr)
-	Expect(secret.Data["error"]).To(BeEmpty())
-}
-
-func getSecret(ctx context.Context, client runtimeclient.Client, tr *pipelinev1.TaskRun) *v1.Secret {
-	name := SecretPrefix + tr.Name
-	secret := v1.Secret{}
-	Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: name}, &secret)).To(Succeed())
-	return &secret
-}
-
-func assertNoSecret(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun) {
-	name := SecretPrefix + tr.Name
-	secret := v1.Secret{}
-	err := client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: name}, &secret)
-	Expect(errors.IsNotFound(err)).To(BeTrue())
-}
-
-func runUserPipeline(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, reconciler *ReconcileTaskRun, name string) *pipelinev1.TaskRun {
-	createUserTaskRun(ctx, g, client, name, "linux/arm64")
-	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
-	Expect(err).ToNot(HaveOccurred())
-	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
-	Expect(err).ToNot(HaveOccurred())
-	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
-	Expect(err).ToNot(HaveOccurred())
-	tr := getUserTaskRun(ctx, g, client, name)
-	if tr.Labels[AssignedHost] == "" {
-		Expect(tr.Annotations[CloudInstanceId]).ToNot(BeEmpty())
-		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: name}})
-		Expect(err).ToNot(HaveOccurred())
-		tr = getUserTaskRun(ctx, g, client, name)
-	}
-	Expect(tr.Labels[AssignedHost]).ToNot(BeEmpty())
-	return tr
-}
-
-func getProvisionTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun) *pipelinev1.TaskRun {
-	list := pipelinev1.TaskRunList{}
-	err := client.List(ctx, &list, &runtimeclient.ListOptions{Namespace: systemNamespace})
-	Expect(err).ToNot(HaveOccurred())
-	for i := range list.Items {
-		if list.Items[i].Labels[UserTaskName] == tr.Name && list.Items[i].Labels[UserTaskNamespace] == tr.Namespace {
-			return &list.Items[i]
-		}
-	}
-	Expect("could not find task").Should(BeEmpty())
-	return nil
-}
-
-func ExpectNoProvisionTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, tr *pipelinev1.TaskRun) {
-	list := pipelinev1.TaskRunList{}
-	err := client.List(ctx, &list)
-	Expect(err).ToNot(HaveOccurred())
-	foundCount := 0
-	for i := range list.Items {
-		if list.Items[i].Labels[AssignedHost] == "" && list.Items[i].Labels[UserTaskName] == tr.Name {
-			foundCount++
-		}
-	}
-	Expect(foundCount).Should(BeNumerically("==", 0))
-}
-
-func getUserTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, name string) *pipelinev1.TaskRun {
-	ret := pipelinev1.TaskRun{}
-	err := client.Get(ctx, types.NamespacedName{Namespace: userNamespace, Name: name}, &ret)
-	Expect(err).ToNot(HaveOccurred())
-	return &ret
-}
-
-func createUserTaskRun(ctx context.Context, g GinkgoTInterface, client runtimeclient.Client, name string, platform string) {
-	tr := &pipelinev1.TaskRun{}
-	tr.Namespace = userNamespace
-	tr.Name = name
-	tr.Labels = map[string]string{"tekton.dev/memberOf": "tasks"}
-	tr.Spec = pipelinev1.TaskRunSpec{
-		Params: []pipelinev1.Param{{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues(platform)}},
-	}
-	tr.Status.TaskSpec = &pipelinev1.TaskSpec{Volumes: []v1.Volume{{Name: "test", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: SecretPrefix + name}}}}}
-	Expect(client.Create(ctx, tr)).ToNot(HaveOccurred())
-}
-
-func createHostConfig() []runtimeclient.Object {
-	cm := createHostConfigMap()
-	sec := v1.Secret{}
-	sec.Name = "awskeys"
-	sec.Namespace = systemNamespace
-	sec.Labels = map[string]string{MultiPlatformSecretLabel: "true"}
-	return []runtimeclient.Object{&cm, &sec}
-}
-
-func createHostConfigMap() v1.ConfigMap {
-	cm := v1.ConfigMap{}
-	cm.Name = HostConfig
-	cm.Namespace = systemNamespace
-	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
-	cm.Data = map[string]string{
-		"allowed-namespaces":     "default,system-.*",
-		"host.host1.address":     "ec2-54-165-44-192.compute-1.amazonaws.com",
-		"host.host1.secret":      "awskeys",
-		"host.host1.concurrency": "4",
-		"host.host1.user":        "ec2-user",
-		"host.host1.platform":    "linux/arm64",
-		"host.host2.address":     "ec2-34-227-115-211.compute-1.amazonaws.com",
-		"host.host2.secret":      "awskeys",
-		"host.host2.concurrency": "4",
-		"host.host2.user":        "ec2-user",
-		"host.host2.platform":    "linux/arm64",
-	}
-	return cm
-}
-
-func createDynamicHostConfig() []runtimeclient.Object {
-	cm := v1.ConfigMap{}
-	cm.Name = HostConfig
-	cm.Namespace = systemNamespace
-	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
-	cm.Data = map[string]string{
-		"additional-instance-tags":               "foo=bar,key=value",
-		"dynamic-platforms":                      "linux/arm64",
-		"dynamic.linux-arm64.type":               "mock",
-		"dynamic.linux-arm64.region":             "us-east-1",
-		"dynamic.linux-arm64.ami":                "ami-03d6a5256a46c9feb",
-		"dynamic.linux-arm64.instance-type":      "t4g.medium",
-		"dynamic.linux-arm64.key-name":           "sdouglas-arm-test",
-		"dynamic.linux-arm64.aws-secret":         "awsiam",
-		"dynamic.linux-arm64.ssh-secret":         "awskeys",
-		"dynamic.linux-arm64.max-instances":      "2",
-		"dynamic.linux-arm64.allocation-timeout": "2",
-	}
-	sec := v1.Secret{}
-	sec.Name = "awskeys"
-	sec.Namespace = systemNamespace
-	sec.Labels = map[string]string{MultiPlatformSecretLabel: "true"}
-	return []runtimeclient.Object{&cm, &sec}
-}
-
-func createDynamicPoolHostConfig() []runtimeclient.Object {
-	cm := v1.ConfigMap{}
-	cm.Name = HostConfig
-	cm.Namespace = systemNamespace
-	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
-	cm.Data = map[string]string{
-		"additional-instance-tags":          "foo=bar,key=value",
-		"dynamic-pool-platforms":            "linux/arm64",
-		"dynamic.linux-arm64.type":          "mock",
-		"dynamic.linux-arm64.region":        "us-east-1",
-		"dynamic.linux-arm64.ami":           "ami-03d6a5256a46c9feb",
-		"dynamic.linux-arm64.instance-type": "t4g.medium",
-		"dynamic.linux-arm64.key-name":      "sdouglas-arm-test",
-		"dynamic.linux-arm64.aws-secret":    "awsiam",
-		"dynamic.linux-arm64.ssh-secret":    "awskeys",
-		"dynamic.linux-arm64.max-instances": "2",
-		"dynamic.linux-arm64.concurrency":   "2",
-		"dynamic.linux-arm64.max-age":       "20",
-	}
-	sec := v1.Secret{}
-	sec.Name = "awskeys"
-	sec.Namespace = systemNamespace
-	sec.Labels = map[string]string{MultiPlatformSecretLabel: "true"}
-	return []runtimeclient.Object{&cm, &sec}
-}
-
-func createLocalHostConfig() []runtimeclient.Object {
-	cm := v1.ConfigMap{}
-	cm.Name = HostConfig
-	cm.Namespace = systemNamespace
-	cm.Labels = map[string]string{ConfigMapLabel: "hosts"}
-	cm.Data = map[string]string{
-		"local-platforms": "linux/arm64",
-	}
-	return []runtimeclient.Object{&cm}
-}
-
-type MockInstance struct {
-	cloud.CloudVMInstance
-	taskRun  string
-	statusOK bool
-}
-
-type MockCloud struct {
-	Running           int
-	Terminated        int
-	Instances         map[cloud.InstanceIdentifier]MockInstance
-	FailGetAddress    bool
-	TimeoutGetAddress bool
-	FailGetState      bool
-	FailCleanUpVMs    bool
-}
-
-func (m *MockCloud) ListInstances(kubeClient runtimeclient.Client, ctx context.Context, instanceTag string) ([]cloud.CloudVMInstance, error) {
-	ret := []cloud.CloudVMInstance{}
-	for _, v := range m.Instances {
-		ret = append(ret, v.CloudVMInstance)
-	}
-	return ret, nil
-}
-
-func (m *MockCloud) CountInstances(kubeClient runtimeclient.Client, ctx context.Context, instanceTag string) (int, error) {
-	return m.Running, nil
-}
-
-func (m *MockCloud) SshUser() string {
-	return "root"
-}
-
-func (m *MockCloud) LaunchInstance(kubeClient runtimeclient.Client, ctx context.Context, taskRunID string, instanceTag string, additionalTags map[string]string) (cloud.InstanceIdentifier, error) {
-	m.Running++
-	// Check that taskRunID is the correct format
-	if strings.Count(taskRunID, ":") != 1 {
-		return "", fmt.Errorf("%s was not of the correct format <namespace>:<name>", taskRunID)
-	}
-	name := strings.Split(taskRunID, ":")[1]
-
-	addr := string(name) + ".host.com"
-	identifier := cloud.InstanceIdentifier(name)
-	newInstance := MockInstance{
-		CloudVMInstance: cloud.CloudVMInstance{InstanceId: identifier, StartTime: time.Now(), Address: addr},
-		taskRun:         string(name) + " task run",
-		statusOK:        true,
-	}
-	m.Instances[identifier] = newInstance
-	return identifier, nil
-}
-
-func (m *MockCloud) TerminateInstance(kubeClient runtimeclient.Client, ctx context.Context, instance cloud.InstanceIdentifier) error {
-	m.Running--
-	m.Terminated++
-	delete(m.Instances, instance)
-	return nil
-}
-
-func (m *MockCloud) GetInstanceAddress(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (string, error) {
-	if m.FailGetAddress {
-		return "", fmt.Errorf("failed")
-	} else if m.TimeoutGetAddress {
-		return "", nil
-	}
-	addr := m.Instances[instanceId].Address
-	if addr == "" {
-		addr = string(instanceId) + ".host.com"
-		instance := m.Instances[instanceId]
-		instance.Address = addr
-		m.Instances[instanceId] = instance
-	}
-	return addr, nil
-}
-
-func (m *MockCloud) GetState(kubeClient runtimeclient.Client, ctx context.Context, instanceId cloud.InstanceIdentifier) (cloud.VMState, error) {
-	if m.FailGetState {
-		return "", fmt.Errorf("failed")
-	}
-
-	instance, ok := m.Instances[instanceId]
-	if !ok {
-		return "", nil
-	}
-	if !instance.statusOK {
-		return cloud.FailedState, nil
-	}
-	return cloud.OKState, nil
-}
-
-// In this implementation of the function, the MockInstance's taskRun value is compared to to the keys in existingTaskRuns for
-// a speedier return.
-func (m *MockCloud) CleanUpVms(ctx context.Context, kubeClient runtimeclient.Client, existingTaskRuns map[string][]string) error {
-	if m.FailCleanUpVMs {
-		return fmt.Errorf("failed")
-	}
-
-	var instancesToDelete []string
-	for k, v := range m.Instances {
-		_, ok := existingTaskRuns[v.taskRun]
-		if !ok {
-			instancesToDelete = append(instancesToDelete, string(k))
-		}
-	}
-
-	for _, instance := range instancesToDelete {
-		m.Running--
-		m.Terminated++
-		delete(m.Instances, cloud.InstanceIdentifier(instance))
-	}
-
-	return nil
-}
-
-func MockCloudSetup(platform string, data map[string]string, systemnamespace string) cloud.CloudProvider {
-	return &cloudImpl
-}
-
-// ConflictingClient simulates conflict errors for testing
-type ConflictingClient struct {
-	runtimeclient.Client
-	ConflictCount int
-	callCount     int
-}
-
-func (c *ConflictingClient) Update(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
-	c.callCount++
-	if c.callCount <= c.ConflictCount {
-		// hardcoded gvk is not perfect but i dunno how to avoid that :(
-		return errors.NewConflict(schema.GroupResource{Group: "tekton.dev", Resource: "taskruns"}, "test", fmt.Errorf("conflict"))
-	}
-	return c.Client.Update(ctx, obj, opts...)
-}
-
-func (c *ConflictingClient) Status() runtimeclient.StatusWriter {
-	return &ConflictingStatusWriter{
-		StatusWriter:  c.Client.Status(),
-		ConflictCount: c.ConflictCount,
-		callCount:     &c.callCount,
-		client:        c.Client,
-	}
-}
-
-type ConflictingStatusWriter struct {
-	runtimeclient.StatusWriter
-	ConflictCount int
-	callCount     *int
-	client        runtimeclient.Client
-}
-
-func (c *ConflictingStatusWriter) Update(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.SubResourceUpdateOption) error {
-	*c.callCount++
-	if *c.callCount <= c.ConflictCount {
-		return errors.NewConflict(schema.GroupResource{Group: "tekton.dev", Resource: "taskruns"}, "test", fmt.Errorf("conflict"))
-	}
-	return c.client.Status().Update(ctx, obj, opts...)
-}
-
-// ErrorClient simulates non-conflict errors for testing
-type ErrorClient struct {
-	runtimeclient.Client
-	Error error
-}
-
-func (c *ErrorClient) Update(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
-	return c.Error
-}


### PR DESCRIPTION
In this PR is the following work:

1. Addressing missing complete provision failure tests for static host pools and dynamic host pools, this was holding back @glevi-rh's metrics work effort and required attention.
2. Refactoring taskrun_test.go into five additional files - one for each host provision type and another file for all the various mocks and the helper methods for the tests. taskrun_test.go was becoming impossible to track and work with, this refactor was highly needed.
3. Fix for bugs found while writing the missing failure tests - dynamicpool.Allocate misuses hostpool.Allocate's returned errors - it doesn't try to launch a new instance if the first host of that platform is in the failed hosts slice, even when the pool isn't at full capacity. The original code around handling hostpool.Allocate's returned errors does try to give the platform another chance at creating a host that doesn't fail, but it was buggy. 
4. A fix for KONFLUX-9460 because I was touching hostpool.Allocate anyways and it was an easy fix.