### PR TITLE
Add metric indication pool size per platform

### DIFF
--- a/pkg/metrics/platform_test.go
+++ b/pkg/metrics/platform_test.go
@@ -17,10 +17,12 @@ var _ = Describe("PlatformMetrics", func() {
 			platform              = "ibm_p"
 			runTasksMetricName    = "multi_platform_controller_running_tasks"
 			waitingTaskMetricName = "multi_platform_controller_waiting_tasks"
+			poolSizeMetricName    = "multi_platform_controller_platform_pool_size"
+			poolSize              = 13
 			expectedValue         = 1
 		)
 		BeforeEach(func(ctx SpecContext) {
-			Expect(RegisterPlatformMetrics(ctx, platform)).NotTo(HaveOccurred())
+			Expect(RegisterPlatformMetrics(ctx, platform, poolSize)).NotTo(HaveOccurred())
 			//resetting counters
 			HandleMetrics(platform, func(m *PlatformMetrics) {
 				m.RunningTasks.WithLabelValues(platform, "test-namespace").Set(0)
@@ -31,6 +33,13 @@ var _ = Describe("PlatformMetrics", func() {
 
 		})
 		When("When appropriate condition happened", func() {
+
+			It("have pool size set", func() {
+				result, err := getGaugeValue(platform, poolSizeMetricName, "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(poolSize))
+			})
+
 			It("should increment running_tasks metric", func() {
 				HandleMetrics(platform, func(m *PlatformMetrics) {
 					m.RunningTasks.WithLabelValues(platform, "test-namespace").Inc()
@@ -58,10 +67,11 @@ var _ = Describe("PlatformMetrics", func() {
 			provisionFailuresMetricName      = "multi_platform_controller_provisioning_failures"
 			cleanupFailuresMetricName        = "multi_platform_controller_cleanup_failures"
 			hostAllocationFailuresMetricName = "multi_platform_controller_host_allocation_failures"
+			poolSize                         = 10
 			expectedValue                    int
 		)
 		BeforeEach(func(ctx SpecContext) {
-			Expect(RegisterPlatformMetrics(ctx, platform)).NotTo(HaveOccurred())
+			Expect(RegisterPlatformMetrics(ctx, platform, poolSize)).NotTo(HaveOccurred())
 		})
 
 		When("When appropriate condition happened", func() {
@@ -107,10 +117,11 @@ var _ = Describe("PlatformMetrics", func() {
 			allocationTimeMetricName = "multi_platform_controller_host_allocation_time"
 			waitTimeMetricName       = "multi_platform_controller_wait_time"
 			taskRunMetricName        = "multi_platform_controller_task_run_time"
+			poolSize                 = 10
 			expectedValue            float64
 		)
 		BeforeEach(func(ctx SpecContext) {
-			Expect(RegisterPlatformMetrics(ctx, platform)).NotTo(HaveOccurred())
+			Expect(RegisterPlatformMetrics(ctx, platform, poolSize)).NotTo(HaveOccurred())
 		})
 
 		When("When appropriate condition happened", func() {
@@ -169,7 +180,7 @@ func getGaugeValue(platform, metricName, namespace string) (int, error) {
 				if m.Gauge == nil {
 					continue
 				}
-				if hasLabel(m.Label, "platform", platform) && hasLabel(m.Label, "taskrun_namespace", namespace) {
+				if hasLabel(m.Label, "platform", platform) && (namespace == "" || hasLabel(m.Label, "taskrun_namespace", namespace)) {
 					return int(m.Gauge.GetValue()), nil
 				}
 			}

--- a/pkg/metrics/platform_test.go
+++ b/pkg/metrics/platform_test.go
@@ -18,7 +18,7 @@ var _ = Describe("PlatformMetrics", func() {
 			runTasksMetricName    = "multi_platform_controller_running_tasks"
 			waitingTaskMetricName = "multi_platform_controller_waiting_tasks"
 			poolSizeMetricName    = "multi_platform_controller_platform_pool_size"
-			poolSize              = 13
+			poolSize              = rand.Intn(100)
 			expectedValue         = 1
 		)
 		BeforeEach(func(ctx SpecContext) {
@@ -67,7 +67,7 @@ var _ = Describe("PlatformMetrics", func() {
 			provisionFailuresMetricName      = "multi_platform_controller_provisioning_failures"
 			cleanupFailuresMetricName        = "multi_platform_controller_cleanup_failures"
 			hostAllocationFailuresMetricName = "multi_platform_controller_host_allocation_failures"
-			poolSize                         = 10
+			poolSize                         = rand.Intn(100)
 			expectedValue                    int
 		)
 		BeforeEach(func(ctx SpecContext) {
@@ -117,7 +117,7 @@ var _ = Describe("PlatformMetrics", func() {
 			allocationTimeMetricName = "multi_platform_controller_host_allocation_time"
 			waitTimeMetricName       = "multi_platform_controller_wait_time"
 			taskRunMetricName        = "multi_platform_controller_task_run_time"
-			poolSize                 = 10
+			poolSize                 = rand.Intn(100)
 			expectedValue            float64
 		)
 		BeforeEach(func(ctx SpecContext) {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -848,7 +848,7 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 	}
 
 	ret := HostPool{hosts: map[string]*Host{}, targetPlatform: targetPlatform}
-	capacity := 0
+	platformCapacity := 0
 	for k, v := range cm.Data {
 		if !strings.HasPrefix(k, "host.") {
 			continue
@@ -881,14 +881,13 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 				return nil, err
 			}
 			host.Concurrency = atoi
-			capacity += atoi
 		default:
 			log.Info("unknown key", "key", key)
 		}
 
 	}
 	r.platformConfig[targetPlatform] = ret
-	err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform, capacity)
+	err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform, platformCapacity)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -790,7 +790,7 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 					eventRecorder:          r.eventRecorder,
 				}
 				r.platformConfig[targetPlatform] = ret
-				err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform)
+				err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform, maxInstances)
 				if err != nil {
 					return nil, err
 				}
@@ -838,7 +838,7 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 					additionalInstanceTags: additionalInstanceTags,
 				}
 				r.platformConfig[targetPlatform] = ret
-				err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform)
+				err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform, maxInstances)
 				if err != nil {
 					return nil, err
 				}
@@ -848,6 +848,7 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 	}
 
 	ret := HostPool{hosts: map[string]*Host{}, targetPlatform: targetPlatform}
+	capacity := 0
 	for k, v := range cm.Data {
 		if !strings.HasPrefix(k, "host.") {
 			continue
@@ -880,13 +881,14 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 				return nil, err
 			}
 			host.Concurrency = atoi
+			capacity += atoi
 		default:
 			log.Info("unknown key", "key", key)
 		}
 
 	}
 	r.platformConfig[targetPlatform] = ret
-	err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform)
+	err = mpcmetrics.RegisterPlatformMetrics(ctx, targetPlatform, capacity)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -881,6 +881,7 @@ func (r *ReconcileTaskRun) readConfiguration(ctx context.Context, targetPlatform
 				return nil, err
 			}
 			host.Concurrency = atoi
+			platformCapacity += atoi
 		default:
 			log.Info("unknown key", "key", key)
 		}


### PR DESCRIPTION
We found it useful to add MPC metric showing pool size for individual platforms. 

It would make it easier to build a graph (together with multi_platform_controller_running_tasks) showing percentage resource usage by MPC so Konflux support/customers would be able to quickly check if that is a bottleneck or not.

Fixes https://issues.redhat.com/browse/KFLUXINFRA-1062