### PR TITLE
Fixup in gauges registration

### DIFF
--- a/pkg/metrics/platform.go
+++ b/pkg/metrics/platform.go
@@ -68,26 +68,23 @@ func RegisterPlatformMetrics(_ context.Context, platform string, poolSize int) e
 	}
 
 	pmetrics.RunningTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: MetricsSubsystem,
-		Name:      "running_tasks",
-		Help:      "The number of currently running tasks on this platform",
-	}, []string{"platform", "taskrun_namespace"})
+		ConstLabels: map[string]string{"platform": platform},
+		Subsystem:   MetricsSubsystem,
+		Name:        "running_tasks",
+		Help:        "The number of currently running tasks on this platform",
+	}, []string{"taskrun_namespace"})
 	if err := metrics.Registry.Register(pmetrics.RunningTasks); err != nil {
-		// This can be called multiple times, so we need to check if it's already registered
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			return err
-		}
+		return err
 	}
 
 	pmetrics.WaitingTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: MetricsSubsystem,
-		Name:      "waiting_tasks",
-		Help:      "The number of tasks waiting for an executor to be available to run",
-	}, []string{"platform", "taskrun_namespace"})
+		ConstLabels: map[string]string{"platform": platform},
+		Subsystem:   MetricsSubsystem,
+		Name:        "waiting_tasks",
+		Help:        "The number of tasks waiting for an executor to be available to run",
+	}, []string{"taskrun_namespace"})
 	if err := metrics.Registry.Register(pmetrics.WaitingTasks); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			return err
-		}
+		return err
 	}
 
 	pmetrics.ProvisionFailures = prometheus.NewCounter(prometheus.CounterOpts{
@@ -118,16 +115,15 @@ func RegisterPlatformMetrics(_ context.Context, platform string, poolSize int) e
 	}
 
 	pmetrics.poolSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: MetricsSubsystem,
-		Name:      "platform_pool_size",
-		Help:      "The size of platform machines pool",
-	}, []string{"platform"})
+		ConstLabels: map[string]string{"platform": platform},
+		Subsystem:   MetricsSubsystem,
+		Name:        "platform_pool_size",
+		Help:        "The size of platform machines pool",
+	}, []string{})
 	if err := metrics.Registry.Register(pmetrics.poolSize); err != nil {
-		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			return err
-		}
+		return err
 	}
-	pmetrics.poolSize.WithLabelValues(platform).Set(float64(poolSize))
+	pmetrics.poolSize.WithLabelValues().Set(float64(poolSize))
 	platformMetrics[platform] = &pmetrics
 	return nil
 }

--- a/pkg/metrics/platform_test.go
+++ b/pkg/metrics/platform_test.go
@@ -25,10 +25,10 @@ var _ = Describe("PlatformMetrics", func() {
 			Expect(RegisterPlatformMetrics(ctx, platform, poolSize)).NotTo(HaveOccurred())
 			//resetting counters
 			HandleMetrics(platform, func(m *PlatformMetrics) {
-				m.RunningTasks.WithLabelValues(platform, "test-namespace").Set(0)
+				m.RunningTasks.WithLabelValues("test-namespace").Set(0)
 			})
 			HandleMetrics(platform, func(m *PlatformMetrics) {
-				m.WaitingTasks.WithLabelValues(platform, "test-namespace").Set(0)
+				m.WaitingTasks.WithLabelValues("test-namespace").Set(0)
 			})
 
 		})
@@ -42,7 +42,7 @@ var _ = Describe("PlatformMetrics", func() {
 
 			It("should increment running_tasks metric", func() {
 				HandleMetrics(platform, func(m *PlatformMetrics) {
-					m.RunningTasks.WithLabelValues(platform, "test-namespace").Inc()
+					m.RunningTasks.WithLabelValues("test-namespace").Inc()
 				})
 				result, err := getGaugeValue(platform, runTasksMetricName, "test-namespace")
 				Expect(err).ToNot(HaveOccurred())
@@ -51,7 +51,7 @@ var _ = Describe("PlatformMetrics", func() {
 
 			It("should increment waiting_tasks metric", func() {
 				HandleMetrics(platform, func(m *PlatformMetrics) {
-					m.WaitingTasks.WithLabelValues(platform, "test-namespace").Inc()
+					m.WaitingTasks.WithLabelValues("test-namespace").Inc()
 				})
 				result, err := getGaugeValue(platform, waitingTaskMetricName, "test-namespace")
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -534,7 +534,7 @@ func (r *ReconcileTaskRun) handleHostAllocation(ctx context.Context, tr *tektona
 		log.Info("host assigned successfully", "host", assignedHost)
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
 			metrics.AllocationTime.Observe(float64(time.Now().Unix() - startTime))
-			metrics.RunningTasks.WithLabelValues(platformLabel(targetPlatform), tr.Namespace).Inc()
+			metrics.RunningTasks.WithLabelValues(tr.Namespace).Inc()
 		})
 	}
 
@@ -543,12 +543,12 @@ func (r *ReconcileTaskRun) handleHostAllocation(ctx context.Context, tr *tektona
 		log.Info("task no longer waiting - host allocated")
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
 			metrics.WaitTime.Observe(float64(time.Now().Unix() - tr.CreationTimestamp.Unix()))
-			metrics.WaitingTasks.WithLabelValues(platformLabel(targetPlatform), tr.Namespace).Dec()
+			metrics.WaitingTasks.WithLabelValues(tr.Namespace).Dec()
 		})
 	} else if !wasWaiting && isWaiting {
 		log.Info("task now waiting for host")
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
-			metrics.WaitingTasks.WithLabelValues(platformLabel(targetPlatform), tr.Namespace).Inc()
+			metrics.WaitingTasks.WithLabelValues(tr.Namespace).Inc()
 		})
 	} else if wasWaiting && isWaiting {
 		log.V(1).Info("task still waiting for host")
@@ -599,7 +599,7 @@ func (r *ReconcileTaskRun) handleHostAssigned(ctx context.Context, tr *tektonapi
 	taskRunDuration := time.Now().Unix() - tr.CreationTimestamp.Unix()
 	mpcmetrics.HandleMetrics(platform, func(metrics *mpcmetrics.PlatformMetrics) {
 		metrics.TaskRunTime.Observe(float64(taskRunDuration))
-		metrics.RunningTasks.WithLabelValues(platformLabel(platform), tr.Namespace).Dec()
+		metrics.RunningTasks.WithLabelValues(tr.Namespace).Dec()
 	})
 
 	// Attempt host deallocation


### PR DESCRIPTION
Platform names were incorrectly moved to dynamic labels which causes registration errors. They must be in const labels.