### PR TITLE
Running tasks counter bug fix

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -620,7 +620,7 @@ func (r *ReconcileTaskRun) handleHostAssigned(ctx context.Context, tr *tektonapi
 	}
 
 	// Update TaskRun with cleanup changes
-	err = r.client.Update(ctx, tr)
+	err = updateTaskRun(ctx, r.client, r.apiReader, tr)
 	if err != nil {
 		log.Error(err, "failed to update TaskRun after cleanup")
 		return reconcile.Result{}, fmt.Errorf("failed to update TaskRun: %w", err)


### PR DESCRIPTION
### What

* Modified the `handleHostAssigned()` function to improve how it updates the TaskRun with cleanup changes.

* Moved the decrement of the `multi_platform_controller_running_tasks` metric to occur only after the TaskRun has been successfully updated.

### Why

* Addresses a race condition that frequently occurs between the MPC controller and the Tekton controller when a TaskRun completes. The new update function now merges annotations and labels to prevent conflicts and ensure a successful TaskRun update.

* Prevents potential multiple decrements of the `multi_platform_controller_running_tasks` counter. Previously, the counter was decremented before a successful update, which could lead to multiple decrements if the cleanup process required retries.