### PR TITLE
KFLUXINFRA-2179: fix hostupdates_test.go flakiness

### DIFF
--- a/pkg/reconciler/taskrun/hostupdate_test.go
+++ b/pkg/reconciler/taskrun/hostupdate_test.go
@@ -18,6 +18,8 @@
 package taskrun
 
 import (
+	"time"
+	
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -116,7 +118,7 @@ var _ = Describe("HostUpdateTaskRunTest", func() {
 				zeroTaskRuns = len(createdList.Items) == 0
 				g.Expect(zeroTaskRuns).To(Equal(shouldFail))
 
-			}).Should(Succeed())
+			}, SpecTimeout(2*time.Minute)).Should(Succeed())
 
 			if !zeroTaskRuns {
 				// set label field filled correctly


### PR DESCRIPTION
Updates the timeout on the Eventually() block to mitigate any  timing/asynchronous/test cleanups time to occur properly.