### PR TITLE
provisioning successes metric bug fix

### DIFF
--- a/pkg/reconciler/taskrun/provision_static_test.go
+++ b/pkg/reconciler/taskrun/provision_static_test.go
@@ -289,6 +289,7 @@ var _ = Describe("Test Static Host Provisioning", func() {
 			}
 			Expect(taskExists).Should(BeFalse())
 		})
+
 		It("should increment Provision Successes metric when provision task succeeds", func(ctx SpecContext) {
 			// Get initial metric value
 			initialSuccesses := getCounterValue("linux/arm64", "provisioning_successes")

--- a/pkg/reconciler/taskrun/provision_static_test.go
+++ b/pkg/reconciler/taskrun/provision_static_test.go
@@ -291,10 +291,12 @@ var _ = Describe("Test Static Host Provisioning", func() {
 		})
 
 		It("should increment Provision Successes metric when provision task succeeds", func(ctx SpecContext) {
+			// run a user task successfully
+			tr := runUserPipeline(ctx, client, reconciler, "test-success")
 			// Get initial metric value
 			initialSuccesses := getCounterValue("linux/arm64", "provisioning_successes")
+			Expect(initialSuccesses).ShouldNot(Equal(-1))
 
-			tr := runUserPipeline(ctx, client, reconciler, "test-success")
 			provision := getProvisionTaskRun(ctx, client, tr)
 
 			runSuccessfulProvision(ctx, provision, client, tr, reconciler)
@@ -304,11 +306,12 @@ var _ = Describe("Test Static Host Provisioning", func() {
 		})
 
 		It("should increment Provision Successes metric by one when provision task succeeds after a conflict", func(ctx SpecContext) {
+			// run a user task with a conflict
+			tr := runUserPipeline(ctx, client, reconciler, "test-success-race")
 			// Get initial metric value
 			initialSuccesses := getCounterValue("linux/arm64", "provisioning_successes")
-
+			Expect(initialSuccesses).ShouldNot(Equal(-1))
 			// Run normal provision setup
-			tr := runUserPipeline(ctx, client, reconciler, "test-success-race")
 			provision := getProvisionTaskRun(ctx, client, tr)
 
 			// Run successful provision with conflict - this will simulate the race condition between the MPC and Tekton

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -374,7 +374,7 @@ func (r *ReconcileTaskRun) handleProvisionTask(ctx context.Context, tr *tektonap
 		}
 	}
 
-	err := updateTaskRun(ctx, r.client, r.apiReader, tr)
+	err := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr)
 	if err == nil {
 		// after a successful provision task, we increment the provisioning_successes metric
 		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
@@ -622,7 +622,7 @@ func (r *ReconcileTaskRun) handleHostAssigned(ctx context.Context, tr *tektonapi
 	}
 
 	// Update TaskRun with cleanup changes
-	err = updateTaskRun(ctx, r.client, r.apiReader, tr)
+	err = UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr)
 	if err != nil {
 		log.Error(err, "failed to update TaskRun after cleanup")
 		return reconcile.Result{}, fmt.Errorf("failed to update TaskRun: %w", err)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -374,15 +374,16 @@ func (r *ReconcileTaskRun) handleProvisionTask(ctx context.Context, tr *tektonap
 		}
 	}
 
-	err := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr)
-	if err == nil {
-		// after a successful provision task, we increment the provisioning_successes metric
-		mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
-			metrics.ProvisionSuccesses.Inc()
-		})
+	if err := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr); err != nil {
+		return reconcile.Result{}, err
 	}
+	
+	// after a successful provision task, we increment the provisioning_successes metric
+	mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
+		metrics.ProvisionSuccesses.Inc()
+	})
 
-	return reconcile.Result{}, err
+	return reconcile.Result{}, nil
 }
 
 // This creates an secret with the 'error' field set

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -377,7 +377,7 @@ func (r *ReconcileTaskRun) handleProvisionTask(ctx context.Context, tr *tektonap
 	if err := UpdateTaskRunWithRetry(ctx, r.client, r.apiReader, tr); err != nil {
 		return reconcile.Result{}, err
 	}
-	
+
 	// after a successful provision task, we increment the provisioning_successes metric
 	mpcmetrics.HandleMetrics(targetPlatform, func(metrics *mpcmetrics.PlatformMetrics) {
 		metrics.ProvisionSuccesses.Inc()

--- a/pkg/reconciler/taskrun/taskrun_helpers_test.go
+++ b/pkg/reconciler/taskrun/taskrun_helpers_test.go
@@ -556,7 +556,6 @@ func getCounterValue(platform string, counter string) float64 {
 
 	// if the platform metrics are not found, return -1
 	if pmetrics == nil {
-		fmt.Println("pmetrics is nil")
 		return -1
 	}
 

--- a/pkg/reconciler/taskrun/taskrun_helpers_test.go
+++ b/pkg/reconciler/taskrun/taskrun_helpers_test.go
@@ -122,6 +122,65 @@ func runSuccessfulProvision(ctx context.Context, provision *pipelinev1.TaskRun, 
 	Expect(secret.Data["error"]).Should(BeEmpty())
 }
 
+func runSuccessfulProvisionWithConflict(ctx context.Context, provision *pipelinev1.TaskRun, client runtimeclient.Client, tr *pipelinev1.TaskRun, reconciler *ReconcileTaskRun) {
+	provision.Status.CompletionTime = &metav1.Time{Time: time.Now().Add(time.Hour * -2)}
+	provision.Status.SetCondition(&apis.Condition{
+		Type:               apis.ConditionSucceeded,
+		Status:             "True",
+		LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(time.Hour * -2)}},
+	})
+	Expect(client.Status().Update(ctx, provision)).ShouldNot(HaveOccurred())
+
+	s := v1.Secret{}
+	s.Name = SecretPrefix + tr.Name
+	s.Namespace = tr.Namespace
+	s.Data = map[string][]byte{}
+	s.Data["id_rsa"] = []byte("expected")
+	s.Data["host"] = []byte("host")
+	s.Data["user-dir"] = []byte("buildir")
+	Expect(client.Create(ctx, &s)).ShouldNot(HaveOccurred())
+
+	// Update TaskRun externally to simulate Tekton modification during processing
+	external := &pipelinev1.TaskRun{}
+	Expect(client.Get(ctx, types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}, external)).Should(Succeed())
+	// if the labels or annotations are nil, we need to make them
+	if external.Labels == nil {
+		external.Labels = make(map[string]string)
+	}
+	if external.Annotations == nil {
+		external.Annotations = make(map[string]string)
+	}
+	external.Labels["external-label"] = "external-value"
+	external.Annotations["external-annotation"] = "external-value"
+	external.Finalizers = append(external.Finalizers, "external-finalizer")
+	Expect(client.Update(ctx, external)).Should(Succeed())
+
+	// Create conflicting client that will cause conflict after a succesfull provision
+	conflictingClient := &ConflictingClient{
+		Client:        client,
+		ConflictCount: 1, // Will fail once with conflict, then succeed
+	}
+
+	// Create reconciler with conflicting client
+	conflictingReconciler := &ReconcileTaskRun{
+		client:                   conflictingClient,
+		apiReader:                reconciler.apiReader,
+		scheme:                   reconciler.scheme,
+		eventRecorder:            reconciler.eventRecorder,
+		operatorNamespace:        reconciler.operatorNamespace,
+		configMapResourceVersion: reconciler.configMapResourceVersion,
+		platformConfig:           reconciler.platformConfig,
+		cloudProviders:           reconciler.cloudProviders,
+	}
+
+	// This reconcile will hit the conflict after a succesfull provision but succeed due to UpdateTaskRunWithRetry
+	_, err := conflictingReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: provision.Namespace, Name: provision.Name}})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	secret := getSecret(ctx, client, tr)
+	Expect(secret.Data["error"]).Should(BeEmpty())
+}
+
 // getSecret retrieves the secret associated with a given user TaskRun.
 
 func getSecret(ctx context.Context, client runtimeclient.Client, tr *pipelinev1.TaskRun) *v1.Secret {

--- a/pkg/reconciler/taskrun/taskrun_helpers_test.go
+++ b/pkg/reconciler/taskrun/taskrun_helpers_test.go
@@ -549,11 +549,14 @@ func (c *ErrorClient) Update(ctx context.Context, obj runtimeclient.Object, opts
 func getCounterValue(platform string, counter string) float64 {
 	metricDto := &dto.Metric{}
 	var pmetrics *mpcmetrics.PlatformMetrics
+
 	mpcmetrics.HandleMetrics(platform, func(metrics *mpcmetrics.PlatformMetrics) {
 		pmetrics = metrics
 	})
+
+	// if the platform metrics are not found, return 0
 	if pmetrics == nil {
-		return -1
+		return 0
 	}
 
 	var err error
@@ -567,8 +570,11 @@ func getCounterValue(platform string, counter string) float64 {
 	case "host_allocation_failures":
 		err = pmetrics.HostAllocationFailures.Write(metricDto)
 	}
+
+	// if we cannot get the counter value, return -1
 	if err != nil {
 		return -1
 	}
+
 	return metricDto.GetCounter().GetValue()
 }

--- a/pkg/reconciler/taskrun/taskrun_helpers_test.go
+++ b/pkg/reconciler/taskrun/taskrun_helpers_test.go
@@ -554,9 +554,10 @@ func getCounterValue(platform string, counter string) float64 {
 		pmetrics = metrics
 	})
 
-	// if the platform metrics are not found, return 0
+	// if the platform metrics are not found, return -1
 	if pmetrics == nil {
-		return 0
+		fmt.Println("pmetrics is nil")
+		return -1
 	}
 
 	var err error

--- a/pkg/reconciler/taskrun/taskrun_helpers_test.go
+++ b/pkg/reconciler/taskrun/taskrun_helpers_test.go
@@ -178,7 +178,7 @@ func runSuccessfulProvisionWithConflict(ctx context.Context, provision *pipeline
 	Expect(err).ShouldNot(HaveOccurred())
 
 	secret := getSecret(ctx, client, tr)
-	Expect(secret.Data["error"]).Should(BeEmpty())
+	Expect(secret.Data).ShouldNot(HaveKey("error"))
 }
 
 // getSecret retrieves the secret associated with a given user TaskRun.


### PR DESCRIPTION
### What
* Changed `client.Update` to `updateTaskRun` to resolve a conflict between Tekton and the MPC controller.
* The `ProvisionSuccesses` counter now only increases if the update is successful.

### Why
* This resolves a bug where the counter would sometimes double. The issue was a **race condition** between the MPC controller and Tekton. This change ensures the counter is accurate.
* This fix addresses the sole point in the metric's lifecycle where a race condition between Tekton and the MPC controller could lead to an incorrect count, ensuring the metric's reliability.