### PR TITLE
KFLUXINFRA-2233 work: Validate the format of the user-provided PLATFORM string value in a TaskRun

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -88,8 +88,6 @@ const (
 	ParamSudoCommands      = "SUDO_COMMANDS"
 )
 
-var errFailedToDeterminePlatform = errors2.New("failed to determine platform")
-
 type ReconcileTaskRun struct {
 	apiReader                client.Reader
 	client                   client.Client
@@ -446,7 +444,7 @@ func (r *ReconcileTaskRun) handleUserTask(ctx context.Context, tr *tektonapi.Tas
 		return reconcile.Result{}, nil
 	}
 
-	targetPlatform, err := extractPlatform(tr)
+	targetPlatform, err := validatePlatform(tr)
 	if err != nil {
 		err := r.createErrorSecret(ctx, tr, "[UNKNOWN]", secretName, err.Error())
 		if err != nil {
@@ -475,15 +473,6 @@ func (r *ReconcileTaskRun) handleUserTask(ctx context.Context, tr *tektonapi.Tas
 		}
 	}
 	return res, err
-}
-
-func extractPlatform(tr *tektonapi.TaskRun) (string, error) {
-	for _, p := range tr.Spec.Params {
-		if p.Name == PlatformParam {
-			return p.Value.StringVal, nil
-		}
-	}
-	return "", errFailedToDeterminePlatform
 }
 
 func (r *ReconcileTaskRun) handleHostAllocation(ctx context.Context, tr *tektonapi.TaskRun, secretName string, targetPlatform string) (reconcile.Result, error) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -61,37 +61,6 @@ var _ = Describe("TaskRun Reconciler General Tests", func() {
 		})
 	})
 
-	// This section tests the utility function responsible for extracting the
-	// target platform from a TaskRun's parameters.
-	Describe("Test extractPlatform function", func() {
-		It("should extract platform from TaskRun parameters successfully", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/amd64")},
-					},
-				},
-			}
-
-			platform, err := extractPlatform(tr)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(platform).Should(Equal("linux/amd64"))
-		})
-
-		It("should return error when PlatformParam parameter is missing", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-					},
-				},
-			}
-
-			_, err := extractPlatform(tr)
-			Expect(err).Should(MatchError(errFailedToDeterminePlatform))
-		})
-	})
-
 	// This section tests the controller's behavior in edge cases where no suitable
 	// hosts can be found for a TaskRun.
 	Describe("Test reconciler behavior when no hosts are configured", func() {
@@ -117,7 +86,7 @@ var _ = Describe("TaskRun Reconciler General Tests", func() {
 			client, reconciler = setupClientAndReconciler(createHostConfig())
 			createUserTaskRun(ctx, client, "test-no-platform", "powerpc")
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: userNamespace, Name: "test-no-platform"}})
-			Expect(err).Should(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 			tr := getUserTaskRun(ctx, client, "test-no-platform")
 
 			secret := getSecret(ctx, client, tr)

--- a/pkg/reconciler/taskrun/validation.go
+++ b/pkg/reconciler/taskrun/validation.go
@@ -1,0 +1,87 @@
+package taskrun
+
+import (
+	"strings"
+
+	errors2 "github.com/pkg/errors"
+	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+var (
+	errInvalidPlatformFormat    = errors2.New("platform must be in format 'label/label' where each label follows Kubernetes RFC 1035 label name format")
+	errMissingPlatformParameter = errors2.New("PLATFORM parameter not found in TaskRun parameters")
+)
+
+// validatePlatformFormat validates a platform string according to the controller's rules
+// Validation rules:
+// - Exceptional platforms: "local", "localhost", "linux/x86_64" bypass format validation
+// - Standard platforms: must be "label/label" format where each label follows RFC 1035
+// - RFC 1035 compliance: lowercase alphanumeric characters and hyphens, start/end with alphanumeric
+//
+// Returns:
+// - nil if platform is valid
+// - errInvalidPlatformFormat if format is incorrect
+func validatePlatformFormat(platform string) error {
+	// Check for exceptional platforms that bypass standard validation
+	if platform == "local" || platform == "localhost" || platform == "linux/x86_64" {
+		return nil
+	}
+
+	// Validate platform format: must be "label/label" where each label follows RFC 1035
+	parts := strings.Split(platform, "/")
+	if len(parts) != 2 {
+		return errInvalidPlatformFormat
+	}
+
+	// Validate each part against RFC 1035 label name rules
+	for _, part := range parts {
+		if p := validation.IsDNS1035Label(part); len(p) != 0 {
+			return errInvalidPlatformFormat
+		}
+	}
+
+	return nil
+}
+
+// validatePlatform extracts and validates the platform parameter from a TaskRun
+// This function combines platform extraction and format validation in a single operation.
+// It first extracts the PLATFORM parameter from the TaskRun, then validates its format.
+//
+// Parameters:
+// - tr: The TaskRun object to extract and validate the platform from
+//
+// Returns:
+// - string: The validated platform value if found and valid
+// - error: errMissingPlatformParameter if PLATFORM parameter not found, or errInvalidPlatformFormat if format is invalid
+func validatePlatform(tr *tektonapi.TaskRun) (string, error) {
+	platform, err := extractPlatform(tr)
+	if err != nil {
+		return "", err
+	}
+
+	if err := validatePlatformFormat(platform); err != nil {
+		return "", err
+	}
+
+	return platform, nil
+}
+
+// extractPlatform extracts the platform parameter value from a TaskRun's parameters
+// This is a helper function for platform validation that searches through the TaskRun's
+// parameter list to find the PLATFORM parameter value.
+//
+// Parameters:
+// - tr: The TaskRun object to extract the platform from
+//
+// Returns:
+// - string: The platform value if found
+// - error: errMissingPlatformParameter if the PLATFORM parameter is not found
+func extractPlatform(tr *tektonapi.TaskRun) (string, error) {
+	for _, p := range tr.Spec.Params {
+		if p.Name == PlatformParam {
+			return p.Value.StringVal, nil
+		}
+	}
+	return "", errMissingPlatformParameter
+}

--- a/pkg/reconciler/taskrun/validation_test.go
+++ b/pkg/reconciler/taskrun/validation_test.go
@@ -1,0 +1,143 @@
+package taskrun
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+// A helper to create a TaskRun with a platform parameter.
+// It accepts a pointer to a string so we can pass 'nil' to simulate a missing parameter.
+func createTrWithPlatform(platform *string) *pipelinev1.TaskRun {
+	tr := &pipelinev1.TaskRun{
+		Spec: pipelinev1.TaskRunSpec{
+			Params: []pipelinev1.Param{},
+		},
+	}
+	if platform != nil {
+		tr.Spec.Params = append(tr.Spec.Params, pipelinev1.Param{
+			Name:  PlatformParam,
+			Value: *pipelinev1.NewStructuredValues(*platform),
+		})
+	}
+	return tr
+}
+
+var _ = Describe("Platform Validation Tests", func() {
+
+	// This section tests the utility function responsible for extracting the
+	// target platform from a TaskRun's parameters.
+	Describe("Test extractPlatform function", func() {
+		It("should extract platform from TaskRun parameters successfully", func() {
+			tr := &pipelinev1.TaskRun{
+				Spec: pipelinev1.TaskRunSpec{
+					Params: []pipelinev1.Param{
+						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/amd64")},
+					},
+				},
+			}
+
+			platform, err := extractPlatform(tr)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(platform).Should(Equal("linux/amd64"))
+		})
+
+		It("should return error when PlatformParam parameter is missing", func() {
+			tr := &pipelinev1.TaskRun{
+				Spec: pipelinev1.TaskRunSpec{
+					Params: []pipelinev1.Param{
+						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
+					},
+				},
+			}
+
+			_, err := extractPlatform(tr)
+			Expect(err).Should(MatchError(errMissingPlatformParameter))
+		})
+	})
+
+	// This section provides thorough unit tests for the platform format validation function.
+	// It is structured to test happy paths, sad paths, and special exceptions distinctly.
+	Describe("The validatePlatformFormat function", func() {
+
+		When("validating a correctly formatted platform string", func() {
+			DescribeTable("it should not return an error",
+				func(platform string) {
+					err := validatePlatformFormat(platform)
+					Expect(err).ShouldNot(HaveOccurred())
+				},
+				Entry("for linux/amd64", "linux/amd64"),
+				Entry("for linux/s390x", "linux/s390x"),
+			)
+		})
+
+		When("validating a special exception platform string", func() {
+			DescribeTable("it should not return an error",
+				func(platform string) {
+					err := validatePlatformFormat(platform)
+					Expect(err).ShouldNot(HaveOccurred())
+				},
+				Entry("for 'local'", "local"),
+				Entry("for 'localhost'", "localhost"),
+				Entry("for 'linux/x86_64'", "linux/x86_64"),
+			)
+		})
+
+		When("validating a malformed platform string", func() {
+			// A helper variable for the length test to keep the table entry clean.
+			longLabel := strings.Repeat("a", 64)
+
+			DescribeTable("it should return an invalid format error",
+				func(platform string) {
+					err := validatePlatformFormat(platform)
+					Expect(err).Should(MatchError(errInvalidPlatformFormat))
+				},
+				// --- Structural Errors ---
+				Entry("because it has too few parts", "linux"),
+				Entry("because it has too many parts", "linux/amd64/extra"),
+				Entry("because the first part is empty", "/amd64"),
+				Entry("because the second part is empty", "linux/"),
+				Entry("because it's just an empty string", ""),
+				Entry("because it has a trailing slash", "linux/amd64/"),
+				// --- DNS-1035 Label Violations ---
+				Entry("because it contains uppercase characters", "linux/AMD64"),
+				Entry("because it contains an underscore", "linux/amd_64"),
+				Entry("because a part starts with a hyphen", "-linux/amd64"),
+				Entry("because a part ends with a hyphen", "linux/amd64-"),
+				Entry("because a part is longer than 63 chars", fmt.Sprintf("linux/%s", longLabel)),
+			)
+		})
+	})
+
+	// This section tests the combined validation function
+	Describe("The validatePlatform function", func() {
+
+		When("the TaskRun contains a valid platform parameter", func() {
+			DescribeTable("it should return the platform and no error",
+				func(platformValue string) {
+					tr := createTrWithPlatform(&platformValue)
+					platform, err := validatePlatform(tr)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(platform).Should(Equal(platformValue))
+				},
+				Entry("for a standard platform", "linux/amd64"),
+				Entry("for the 'linux/x86_64' exception", "linux/x86_64"),
+			)
+		})
+
+		When("the TaskRun contains an invalid or missing platform parameter", func() {
+			DescribeTable("it should return the corresponding error",
+				func(platformValue *string, expectedError error) {
+					tr := createTrWithPlatform(platformValue)
+					_, err := validatePlatform(tr)
+					Expect(err).Should(MatchError(expectedError))
+				},
+				Entry("when the parameter is missing", nil, errMissingPlatformParameter),
+				Entry("when the parameter format is invalid", &[]string{"koko_hazamar/moshe_ata_lo_kipod"}[0], errInvalidPlatformFormat),
+			)
+		})
+	})
+})


### PR DESCRIPTION
This PR includes the fix for the problem that started this whole mess - nothing verifies that a platform listen in a user TaskRun's PLATFORM parameter is actually valid. 
Validation for the [host platform field](https://github.com/konflux-ci/multi-platform-controller/pull/491#discussion_r2185914732):  label/label, where a label is respecting the [RFC 1035 format.](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names). This is done in a format validation method.
extractPlatform has been moved to the new validation code file, and is not longer directly called by taskrun.go's handleUserTask. Instead, a new method which both checks the PLATFORM parameter even exists and can be extracted, and then validates the format of PLATFORM's string value.