### PR TITLE
ci: allow warnings from SARIF-based tools

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -77,6 +79,8 @@ jobs:
   security_scan:
     name: Security scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4


### PR DESCRIPTION
For lint and security warnings to show up in PRs, jobs need to have permissions to write to security events.  Enable them for both linting and gosec scanners.