### PR TITLE
improve availability metric

### DIFF
--- a/pkg/metrics/backend_probe.go
+++ b/pkg/metrics/backend_probe.go
@@ -24,20 +24,22 @@ func (q *BackendProbe) CheckAvailability(_ context.Context) error {
 	// if we split the loads and the stores into two separate operations, we
 	// could miss some success and failure events, so instead load and store
 	// atomically in one operation
-	successes := q.successes.Swap(0)
-	failures := q.failures.Swap(0)
-	if successes == 0 {
-		//ok, let's consider > 1 error and 0 success not a good sign...
-		if failures > 1 {
-			return fmt.Errorf("failure threshold high")
-		}
-	} else {
-		//non-zero successes here, let's check the error to success rate
-		if float64(failures)/float64(successes) > errorThreshold {
-			return fmt.Errorf("failure threshold high")
-		}
+	successes := float64(q.successes.Swap(0))
+	failures := float64(q.failures.Swap(0))
+
+	switch {
+	// if success+failures == 0: nothing happened; we need to handle it
+	//    separately to avoid division by 0.
+	// if success+failures == 1:
+	//   failures == 1: we don't have enough data to fire an alarm
+	//   successes == 1: everything is good
+	case successes+failures <= 1:
+		return nil
+	case failures/(successes+failures) > errorThreshold:
+		return fmt.Errorf("failure threshold high")
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (q *BackendProbe) Success() {

--- a/pkg/metrics/backend_probe_test.go
+++ b/pkg/metrics/backend_probe_test.go
@@ -32,6 +32,11 @@ var _ = Describe("Backend_Probe CheckAvailability unit tests", func() {
 			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
 		})
 
+		It("should pass with one successes and one failure", func(ctx context.Context) {
+			probe = setupProbeWithCounts(1, 1)
+			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
+		})
+
 		It("should pass with many successes and no failures", func(ctx context.Context) {
 			probe = setupProbeWithCounts(20, 0)
 			Expect(probe.CheckAvailability(ctx)).Should(Succeed())
@@ -50,16 +55,17 @@ var _ = Describe("Backend_Probe CheckAvailability unit tests", func() {
 		})
 
 		It("should fail with a failure rate clearly above the threshold", func(ctx context.Context) {
-			probe = setupProbeWithCounts(10, 9) // success/failures ratio - 0.9
+			probe = setupProbeWithCounts(10, 90) // success/failures ratio - 0.9
 			Expect(probe.CheckAvailability(ctx)).Should(HaveOccurred())
 		})
 	})
 
 	When("testing errorThreshold boundary conditions", func() {
 
-		baseSuccesses := 100
+		totalRuns := 100
 		// A count of failures that should result in a ratio == errorThreshold
-		failuresAtEdge := int(float64(baseSuccesses) * errorThreshold)
+		failuresAtEdge := int(float64(totalRuns) * errorThreshold)
+		baseSuccesses := totalRuns - failuresAtEdge
 
 		// Below are calculations written with the assumption that errorThreshold will never be less than 0.1, because
 		// it's a less realistic situation in production. It also feels like a threshold that's way too accurate


### PR DESCRIPTION
This PR fixex the scenario in which we have `successes=1` and `failures=1`.
The proposed approach is not a long-term solution and we should completely revisit this metric.

Signed-off-by: Francesco Ilario <filario@redhat.com>
