### PR TITLE
KFLUXINFRA-2234 first commit - moving to reading host configuration data and validating it before returning it to readConfigurations

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -89,7 +89,7 @@ func (ec AWSEc2DynamicConfig) LaunchInstance(kubeClient client.Client, ctx conte
 	log.Info("Attempting to launch AWS EC2 instance", "taskRunName", taskRunName)
 
 	// Use AWS credentials and configuration to create an EC2 client
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create an EC2 client: %w", err)
 	}
@@ -126,7 +126,7 @@ func (ec AWSEc2DynamicConfig) CountInstances(kubeClient client.Client, ctx conte
 	log.Info("Attempting to count AWS EC2 instances")
 
 	// Use AWS credentials and configuration to create an EC2 client
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return -1, fmt.Errorf("failed to create an EC2 client: %w", err)
 	}
@@ -166,7 +166,7 @@ func (ec AWSEc2DynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx c
 	log.Info("Attempting to get AWS EC2 instance's IP address", "instanceID", instanceID)
 
 	// Use AWS credentials and configuration to create an EC2 client
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create an EC2 client: %w", err)
 	}
@@ -201,7 +201,7 @@ func (ec AWSEc2DynamicConfig) TerminateInstance(kubeClient client.Client, ctx co
 	log.Info("Attempting to terminate AWS EC2 instance", "instanceID", instanceID)
 
 	// Use AWS credentials and configuration to create an EC2 client
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create an EC2 client: %w", err)
 	}
@@ -216,7 +216,7 @@ func (ec AWSEc2DynamicConfig) ListInstances(kubeClient client.Client, ctx contex
 	log.Info("Attempting to list AWS EC2 instances")
 
 	// Use AWS credentials and configuration to create an EC2 client
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create an EC2 client: %w", err)
 	}
@@ -281,7 +281,7 @@ func (ec AWSEc2DynamicConfig) GetState(kubeClient client.Client, ctx context.Con
 	}
 
 	// Create an EC2 client and get instance
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to create an EC2 client: %w", err)
 	}
@@ -310,7 +310,7 @@ func (ec AWSEc2DynamicConfig) CleanUpVms(ctx context.Context, kubeClient client.
 	log.Info("Attempting to clean up orphaned AWS EC2 instances")
 
 	// Create an EC2 client
-	ec2Client, err := ec.createClient(kubeClient, ctx)
+	ec2Client, err := ec.CreateClient(kubeClient, ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create an EC2 client: %w", err)
 	}

--- a/pkg/aws/ec2_helpers.go
+++ b/pkg/aws/ec2_helpers.go
@@ -19,8 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// pingIPAddress tries to resolve the IP address ip. An error is returned if ipAddress couldn't be reached.
-func pingIPAddress(ipAddress string) error {
+// PingIPAddress tries to resolve the IP address ip. An error is returned if ipAddress couldn't be reached.
+func PingIPAddress(ipAddress string) error {
 	server, _ := net.ResolveTCPAddr("tcp", ipAddress+":22")
 	conn, err := net.DialTCP("tcp", nil, server)
 	if err != nil {
@@ -43,7 +43,7 @@ func (ec AWSEc2DynamicConfig) validateIPAddress(ctx context.Context, instance *t
 	}
 
 	if ip != "" {
-		err = pingIPAddress(ip)
+		err = PingIPAddress(ip)
 	}
 	if err != nil {
 		log := logr.FromContextOrDiscard(ctx)
@@ -53,8 +53,8 @@ func (ec AWSEc2DynamicConfig) validateIPAddress(ctx context.Context, instance *t
 	return ip, err
 }
 
-// createClient uses AWS credentials and an EC2 configuration to create and return an EC2 client.
-func (ec AWSEc2DynamicConfig) createClient(kubeClient client.Client, ctx context.Context) (*ec2.Client, error) {
+// CreateClient uses AWS credentials and an EC2 configuration to create and return an EC2 client.
+func (ec AWSEc2DynamicConfig) CreateClient(kubeClient client.Client, ctx context.Context) (*ec2.Client, error) {
 	secretCredentials := SecretCredentialsProvider{Name: ec.Secret, Namespace: ec.SystemNamespace, Client: kubeClient}
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithCredentialsProvider(secretCredentials),

--- a/pkg/aws/ec2_helpers_test.go
+++ b/pkg/aws/ec2_helpers_test.go
@@ -164,7 +164,7 @@ var _ = Describe("AWS EC2 Helper Functions", func() {
 		DescribeTable("Testing the ability to ping a remote AWS ec2 instance via SSH",
 			func(testInstanceIP string, shouldFail bool) {
 
-				err := pingIPAddress(testInstanceIP)
+				err := PingIPAddress(testInstanceIP)
 
 				if !shouldFail {
 					Expect(err).Should(BeNil())

--- a/pkg/reconciler/taskrun/config.go
+++ b/pkg/reconciler/taskrun/config.go
@@ -1,0 +1,391 @@
+package taskrun
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// Default allocation timeout for dynamic platforms in seconds (10 minutes)
+	defaultAllocationTimeout = 600
+)
+
+// parsePlatformList parses a comma-separated list of platforms, validates each one, and returns a slice of valid
+// platforms. Handles trailing commas.
+func parsePlatformList(platformList string, platformType string) ([]string, error) {
+	if platformList == "" {
+		return []string{}, nil
+	}
+
+	platforms := strings.Split(platformList, ",")
+	result := []string{}
+	for i, platform := range platforms {
+		platform = strings.TrimSpace(platform)
+		if platform == "" {
+			// Allow empty strings only at the end (from trailing commas)
+			if i == len(platforms)-1 {
+				continue
+			}
+			return nil, fmt.Errorf("invalid %s platform '': empty platform in middle of list", platformType)
+		}
+		if err := validatePlatformFormat(platform); err != nil {
+			return nil, fmt.Errorf("invalid %s platform '%s': %w", platformType, platform, err)
+		}
+		result = append(result, platform)
+	}
+	return result, nil
+}
+
+// ClusterHostConfig represents the complete host configuration from ConfigMap
+type ClusterHostConfig struct {
+	LocalPlatforms         []string
+	DynamicPlatforms       map[string]DynamicPlatformConfig
+	DynamicPoolPlatforms   map[string]DynamicPoolPlatformConfig
+	StaticPlatforms        map[string]StaticHostConfig
+	DefaultInstanceTag     string
+	AdditionalInstanceTags map[string]string
+}
+
+// DynamicPlatformConfig holds configuration for a single dynamic platform
+type DynamicPlatformConfig struct {
+	Type              string `mapstructure:"type"`
+	MaxInstances      int    `mapstructure:"max-instances"`
+	InstanceTag       string `mapstructure:"instance-tag,omitempty"`
+	AllocationTimeout int64  `mapstructure:"allocation-timeout,omitempty"`
+	SSHSecret         string `mapstructure:"ssh-secret"`
+	SudoCommands      string `mapstructure:"sudo-commands,omitempty"`
+}
+
+// DynamicPoolPlatformConfig holds configuration for a single dynamic platform in a host pool
+type DynamicPoolPlatformConfig struct {
+	Type         string `mapstructure:"type"`
+	MaxInstances int    `mapstructure:"max-instances"`
+	Concurrency  int    `mapstructure:"concurrency"`
+	MaxAge       int    `mapstructure:"max-age"` // in minutes
+	InstanceTag  string `mapstructure:"instance-tag,omitempty"`
+	SSHSecret    string `mapstructure:"ssh-secret"`
+}
+
+// StaticHostConfig represents a single static host configuration
+type StaticHostConfig struct {
+	Address     string `mapstructure:"address"`
+	User        string `mapstructure:"user"`
+	Platform    string `mapstructure:"platform"`
+	Secret      string `mapstructure:"secret"`
+	Concurrency int    `mapstructure:"concurrency"`
+}
+
+// ParseAndValidate parses and validates host configuration data from a ConfigMap
+// This function extracts configuration for all platform types (local, dynamic, dynamic-pool, static)
+// and validates each field according to the controller's validation rules.
+//
+// Parameters:
+// - ctx: Context for AWS resource validation
+// - kubeClient: Kubernetes client for AWS resource validation
+// - data: The ConfigMap data map containing host configuration
+// - systemNamespace: System namespace for AWS resource validation
+//
+// Returns:
+// - *ClusterHostConfig: The parsed and validated configuration
+// - error: Validation error if any field fails validation
+func ParseAndValidate(ctx context.Context, kubeClient client.Client, data map[string]string, systemNamespace string) (*ClusterHostConfig, error) {
+	config := &ClusterHostConfig{
+		LocalPlatforms:         []string{},
+		DynamicPlatforms:       make(map[string]DynamicPlatformConfig),
+		DynamicPoolPlatforms:   make(map[string]DynamicPoolPlatformConfig),
+		StaticPlatforms:        make(map[string]StaticHostConfig),
+		AdditionalInstanceTags: make(map[string]string),
+	}
+
+	// Parse local platforms
+	localPlatforms, err := parsePlatformList(data[LocalPlatforms], "local")
+	if err != nil {
+		return nil, err
+	}
+	config.LocalPlatforms = localPlatforms
+
+	// Parse dynamic platforms
+	dynamicPlatforms, err := parsePlatformList(data[DynamicPlatforms], "dynamic")
+	if err != nil {
+		return nil, err
+	}
+	for _, platform := range dynamicPlatforms {
+		platformConfigName := strings.ReplaceAll(platform, "/", "-")
+		prefix := "dynamic." + platformConfigName + "."
+
+		// Parse and validate dynamic platform configuration
+		dynamicConfig := DynamicPlatformConfig{}
+
+		// Type field (required)
+		if typeName := data[prefix+"type"]; typeName != "" {
+			dynamicConfig.Type = typeName
+		} else {
+			return nil, fmt.Errorf("dynamic platform '%s': type field is required", platform)
+		}
+
+		// Max instances (required)
+		if maxInstancesStr := data[prefix+"max-instances"]; maxInstancesStr != "" {
+			maxInstances, err := validateMaxInstances(maxInstancesStr)
+			if err != nil {
+				return nil, fmt.Errorf("dynamic platform '%s': invalid max-instances '%s': %w", platform, maxInstancesStr, err)
+			}
+			dynamicConfig.MaxInstances = maxInstances
+		} else {
+			return nil, fmt.Errorf("dynamic platform '%s': max-instances field is required", platform)
+		}
+
+		// Instance tag (optional)
+		if instanceTag := data[prefix+"instance-tag"]; instanceTag != "" {
+			if err := validateDynamicInstanceTag(platformConfigName, instanceTag); err != nil {
+				return nil, fmt.Errorf("dynamic platform '%s': invalid instance-tag '%s': %w", platform, instanceTag, err)
+			}
+			dynamicConfig.InstanceTag = instanceTag
+		}
+
+		// Allocation timeout (optional)
+		if timeoutStr := data[prefix+"allocation-timeout"]; timeoutStr != "" {
+			timeout, err := validateMaxAllocationTimeout(timeoutStr)
+			if err != nil {
+				return nil, fmt.Errorf("dynamic platform '%s': invalid allocation-timeout '%s': %w", platform, timeoutStr, err)
+			}
+			dynamicConfig.AllocationTimeout = int64(timeout)
+		} else {
+			// Default to 10 minutes if not specified
+			dynamicConfig.AllocationTimeout = int64(defaultAllocationTimeout)
+		}
+
+		// SSH secret (required)
+		if sshSecret := data[prefix+"ssh-secret"]; sshSecret != "" {
+			// For AWS platforms, just validate that there is a value
+			if dynamicConfig.Type == "aws" {
+				// AWS platforms: ensure the field has a non-empty value
+				if strings.TrimSpace(sshSecret) == "" {
+					return nil, fmt.Errorf("dynamic platform '%s': ssh-secret cannot be empty for AWS platforms", platform)
+				}
+				dynamicConfig.SSHSecret = sshSecret
+			} else {
+				// IBM platforms: validate using validateIBMHostSecret
+				if err := validateIBMHostSecret(platform, sshSecret); err != nil {
+					return nil, fmt.Errorf("dynamic platform '%s': invalid ssh-secret '%s': %w", platform, sshSecret, err)
+				}
+				dynamicConfig.SSHSecret = sshSecret
+			}
+		} else {
+			return nil, fmt.Errorf("dynamic platform '%s': ssh-secret field is required", platform)
+		}
+
+		// Sudo commands (optional)
+		if sudoCommands := data[prefix+"sudo-commands"]; sudoCommands != "" {
+			dynamicConfig.SudoCommands = sudoCommands
+		}
+
+		// For AWS platforms, validate AWS resources
+		// TODO: Re-enable this at the start of KFLUXINFRA-2328
+		// if dynamicConfig.Type == "aws" {
+		// 	awsConfig := AWSResourceValidationConfig{
+		// 		Region:          data[prefix+"region"],
+		// 		AMI:             data[prefix+"ami"],
+		// 		SecurityGroupId: data[prefix+"security-group-id"],
+		// 		SubnetId:        data[prefix+"subnet-id"],
+		// 		KeyName:         data[prefix+"key-name"],
+		// 		AWSSecret:       dynamicConfig.SSHSecret,
+		// 		SystemNamespace: systemNamespace,
+		// 	}
+		// 	if err := validateAWSResources(ctx, kubeClient, awsConfig); err != nil {
+		// 		return nil, fmt.Errorf("dynamic platform '%s': AWS resource validation failed: %w", platform, err)
+		// 	}
+		// }
+
+		config.DynamicPlatforms[platform] = dynamicConfig
+	}
+
+	// Parse dynamic pool platforms
+	dynamicPoolPlatforms, err := parsePlatformList(data[DynamicPoolPlatforms], "dynamic pool")
+	if err != nil {
+		return nil, err
+	}
+	for _, platform := range dynamicPoolPlatforms {
+		platformConfigName := strings.ReplaceAll(platform, "/", "-")
+		prefix := "dynamic." + platformConfigName + "."
+
+		// Parse and validate dynamic pool platform configuration
+		poolConfig := DynamicPoolPlatformConfig{}
+
+		// Type field (required)
+		if typeName := data[prefix+"type"]; typeName != "" {
+			poolConfig.Type = typeName
+		} else {
+			return nil, fmt.Errorf("dynamic pool platform '%s': type field is required", platform)
+		}
+
+		// Max instances (required)
+		if maxInstancesStr := data[prefix+"max-instances"]; maxInstancesStr != "" {
+			maxInstances, err := validateMaxInstances(maxInstancesStr)
+			if err != nil {
+				return nil, fmt.Errorf("dynamic pool platform '%s': invalid max-instances '%s': %w", platform, maxInstancesStr, err)
+			}
+			poolConfig.MaxInstances = maxInstances
+		} else {
+			return nil, fmt.Errorf("dynamic pool platform '%s': max-instances field is required", platform)
+		}
+
+		// Concurrency (required)
+		if concurrencyStr := data[prefix+"concurrency"]; concurrencyStr != "" {
+			concurrency, err := validateNumericValue(concurrencyStr, maxStaticConcurrency)
+			if err != nil {
+				return nil, fmt.Errorf("dynamic pool platform '%s': invalid concurrency '%s': %w", platform, concurrencyStr, err)
+			}
+			poolConfig.Concurrency = concurrency
+		} else {
+			return nil, fmt.Errorf("dynamic pool platform '%s': concurrency field is required", platform)
+		}
+
+		// Max age (required)
+		if maxAgeStr := data[prefix+"max-age"]; maxAgeStr != "" {
+			maxAge, err := validateNumericValue(maxAgeStr, maxPoolHostAge)
+			if err != nil {
+				return nil, fmt.Errorf("dynamic pool platform '%s': invalid max-age '%s': %w", platform, maxAgeStr, err)
+			}
+			poolConfig.MaxAge = maxAge
+		} else {
+			return nil, fmt.Errorf("dynamic pool platform '%s': max-age field is required", platform)
+		}
+
+		// Instance tag (optional)
+		if instanceTag := data[prefix+"instance-tag"]; instanceTag != "" {
+			if err := validateDynamicInstanceTag(platformConfigName, instanceTag); err != nil {
+				return nil, fmt.Errorf("dynamic pool platform '%s': invalid instance-tag '%s': %w", platform, instanceTag, err)
+			}
+			poolConfig.InstanceTag = instanceTag
+		}
+
+		// SSH secret (required)
+		if sshSecret := data[prefix+"ssh-secret"]; sshSecret != "" {
+			// For IBM platforms (non-AWS), validate using validateIBMHostSecret
+			if poolConfig.Type != "aws" {
+				if err := validateIBMHostSecret(platform, sshSecret); err != nil {
+					return nil, fmt.Errorf("dynamic pool platform '%s': invalid ssh-secret '%s': %w", platform, sshSecret, err)
+				}
+			}
+			poolConfig.SSHSecret = sshSecret
+		} else {
+			return nil, fmt.Errorf("dynamic pool platform '%s': ssh-secret field is required", platform)
+		}
+
+		// For AWS platforms, validate AWS resources
+		// TODO: Re-enable this with proper mocking in tests at the start of KFLUXINFRA-2328
+		// if poolConfig.Type == "aws" {
+		// 	awsConfig := AWSResourceValidationConfig{
+		// 		Region:          data[prefix+"region"],
+		// 		AMI:             data[prefix+"ami"],
+		// 		SecurityGroupId: data[prefix+"security-group-id"],
+		// 		SubnetId:        data[prefix+"subnet-id"],
+		// 		KeyName:         data[prefix+"key-name"],
+		// 		AWSSecret:       poolConfig.SSHSecret,
+		// 		SystemNamespace: systemNamespace,
+		// 	}
+		// 	if err := validateAWSResources(ctx, kubeClient, awsConfig); err != nil {
+		// 		return nil, fmt.Errorf("dynamic pool platform '%s': AWS resource validation failed: %w", platform, err)
+		// 	}
+		// }
+
+		config.DynamicPoolPlatforms[platform] = poolConfig
+	}
+
+	// Parse static hosts (host.<name>.* pattern)
+	staticHosts := make(map[string]StaticHostConfig)
+	for key, value := range data {
+		if !strings.HasPrefix(key, "host.") {
+			continue
+		}
+
+		// Extract host name and field from key
+		key = key[len("host."):]
+		pos := strings.LastIndex(key, ".")
+		if pos == -1 {
+			continue
+		}
+
+		hostName := key[0:pos]
+		field := key[pos+1:]
+
+		// Get or create host config
+		hostConfig, exists := staticHosts[hostName]
+		if !exists {
+			hostConfig = StaticHostConfig{}
+		}
+
+		// Parse and validate each field
+		switch field {
+		case "address":
+			if err := validateIP(value); err != nil {
+				return nil, fmt.Errorf("static host '%s': invalid address '%s': %w", hostName, value, err)
+			}
+			hostConfig.Address = value
+
+		case "user":
+			if strings.TrimSpace(value) == "" {
+				return nil, fmt.Errorf("static host '%s': user field cannot be empty", hostName)
+			}
+			hostConfig.User = value
+
+		case "platform":
+			if err := validatePlatformFormat(value); err != nil {
+				return nil, fmt.Errorf("static host '%s': invalid platform '%s': %w", hostName, value, err)
+			}
+			hostConfig.Platform = value
+
+		case "secret":
+			// For IBM platforms, validate using validateIBMHostSecret
+			if strings.Contains(hostConfig.Platform, "s390x") || strings.Contains(hostConfig.Platform, "ppc64le") {
+				if err := validateIBMHostSecret(hostConfig.Platform, value); err != nil {
+					return nil, fmt.Errorf("static host '%s': invalid secret '%s': %w", hostName, value, err)
+				}
+			}
+			hostConfig.Secret = value
+
+		case "concurrency":
+			concurrency, err := validateNumericValue(value, maxStaticConcurrency)
+			if err != nil {
+				return nil, fmt.Errorf("static host '%s': invalid concurrency '%s': %w", hostName, value, err)
+			}
+			hostConfig.Concurrency = concurrency
+		}
+
+		staticHosts[hostName] = hostConfig
+	}
+
+	// Add validated static hosts to config, keyed by hostname
+	for hostName, hostConfig := range staticHosts {
+		// Only validate that address field was provided (others are validated during parsing)
+		if hostConfig.Address == "" {
+			return nil, fmt.Errorf("static host '%s': address field is required", hostName)
+		}
+
+		config.StaticPlatforms[hostName] = hostConfig
+	}
+
+	// Parse default instance tag
+	if instanceTag := data[DefaultInstanceTag]; instanceTag != "" {
+		config.DefaultInstanceTag = instanceTag
+	}
+
+	// Parse additional instance tags
+	if additionalTags := data[AdditionalInstanceTags]; additionalTags != "" {
+		tags := strings.Split(additionalTags, ",")
+		for _, tag := range tags {
+			tag = strings.TrimSpace(tag)
+			parts := strings.Split(tag, "=")
+			if len(parts) >= 2 {
+				config.AdditionalInstanceTags[parts[0]] = parts[1]
+			} else {
+				return nil, fmt.Errorf("invalid additional instance tag format '%s': must be key=value", tag)
+			}
+		}
+	}
+
+	return config, nil
+}

--- a/pkg/reconciler/taskrun/config_test.go
+++ b/pkg/reconciler/taskrun/config_test.go
@@ -1,0 +1,746 @@
+// This file contains tests for the host configuration parsing and validation functions.
+// It covers parsing of local platforms, dynamic platforms, dynamic pool platforms, static hosts,
+// and instance tagging configuration from ConfigMap data into structured ClusterHostConfig objects.
+package taskrun
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+//TODO: add 'const systemNamespace = "multi-platform-controller"' here at the start of KFLUXINFRA-2328
+
+var _ = Describe("Host Configuration Parsing and Validation Tests", func() {
+
+	// This section tests the parsePlatformList helper function
+	Describe("The parsePlatformList helper function", func() {
+
+		When("parsing valid platform lists", func() {
+			DescribeTable("should parse platform lists correctly",
+				func(ctx SpecContext, input string, platformType string, expected []string) {
+					result, _ := parsePlatformList(input, platformType)
+					Expect(result).Should(Equal(expected))
+				},
+				Entry("empty string returns empty slice", "", "test",
+					[]string{}),
+				Entry("single platform", "linux/amd64", "test",
+					[]string{"linux/amd64"}),
+				Entry("multiple platforms", "linux/amd64,linux/arm64", "test",
+					[]string{"linux/amd64", "linux/arm64"}),
+				Entry("with whitespace", "linux/amd64 , linux/arm64 , linux/s390x", "test",
+					[]string{"linux/amd64", "linux/arm64", "linux/s390x"}),
+				Entry("with trailing comma", "linux/amd64,linux/arm64,", "test",
+					[]string{"linux/amd64", "linux/arm64"}),
+			)
+		})
+
+		When("parsing invalid platform lists", func() {
+			DescribeTable("should return error for various invalid inputs",
+				func(ctx SpecContext, input string, platformType string, expectedErrorSubstring string) {
+					_, err := parsePlatformList(input, platformType)
+					Expect(err.Error()).Should(ContainSubstring(expectedErrorSubstring))
+				},
+				Entry("invalid platform format",
+					"invalid_platform", "test", "invalid test platform 'invalid_platform'"),
+				Entry("empty platform in middle of list",
+					"linux/amd64,,linux/arm64", "test", "empty platform in middle of list"),
+				Entry("one platform in list is invalid",
+					"linux/amd64,bad_format,linux/arm64", "test", "invalid test platform 'bad_format'"),
+			)
+		})
+	})
+
+	// This section tests parsing and validation of local platform configurations
+	Describe("The ParseAndValidate function with local platforms", func() {
+
+		When("parsing valid local platform configurations", func() {
+			DescribeTable("should parse local platform configurations correctly",
+				func(ctx SpecContext, localPlatforms string, expected []string) {
+					data := map[string]string{
+						LocalPlatforms: localPlatforms,
+					}
+					config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+					Expect(config.LocalPlatforms).Should(Equal(expected))
+				},
+				Entry("single local platform", "linux/amd64",
+					[]string{"linux/amd64"}),
+				Entry("multiple local platforms", "linux/amd64,linux/s390x",
+					[]string{"linux/amd64", "linux/s390x"}),
+				Entry("local platforms with whitespace", "linux/amd64, local , localhost",
+					[]string{"linux/amd64", "local", "localhost"}),
+				Entry("special exception platforms", "local,localhost,linux/x86_64",
+					[]string{"local", "localhost", "linux/x86_64"}),
+			)
+
+			DescribeTable("should return empty list for various empty configurations",
+				func(ctx SpecContext, data map[string]string) {
+					config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+					Expect(config.LocalPlatforms).Should(BeEmpty())
+				},
+				Entry("when local platforms is empty string", map[string]string{
+					LocalPlatforms: "",
+				}),
+				Entry("when local platforms is not present", map[string]string{}),
+			)
+		})
+
+		When("parsing invalid local platform configurations", func() {
+			DescribeTable("should return error for invalid platform formats",
+				func(ctx SpecContext, localPlatforms string, expectedErrorSubstring string) {
+					data := map[string]string{
+						LocalPlatforms: localPlatforms,
+					}
+					_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(ContainSubstring(expectedErrorSubstring))
+				},
+				Entry("for invalid platform format",
+					"invalid_platform", "invalid local platform 'invalid_platform'"),
+				Entry("when one platform in list is invalid",
+					"linux/arm64,bad/format/too/many,linux/s390x", "invalid local platform 'bad/format/too/many'"),
+			)
+		})
+	})
+
+	// This section tests parsing and validation of dynamic platform configurations
+	Describe("The ParseAndValidate function with dynamic platforms", func() {
+
+		When("parsing valid AWS dynamic platform configurations", func() {
+			It("should parse complete AWS dynamic platform with all optional fields", func(ctx SpecContext) {
+				data := map[string]string{
+					DynamicPlatforms:                         "linux/amd64",
+					"dynamic.linux-amd64.type":               "aws",
+					"dynamic.linux-amd64.max-instances":      "10",
+					"dynamic.linux-amd64.allocation-timeout": "900",
+					"dynamic.linux-amd64.ssh-secret":         "aws-secret",
+					"dynamic.linux-amd64.sudo-commands":      "yum install -y docker",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DynamicPlatforms).Should(HaveKey("linux/amd64"))
+
+				dynamicConfig := config.DynamicPlatforms["linux/amd64"]
+				Expect(dynamicConfig.Type).Should(Equal("aws"))
+				Expect(dynamicConfig.MaxInstances).Should(Equal(10))
+				Expect(dynamicConfig.AllocationTimeout).Should(Equal(int64(900)))
+				Expect(dynamicConfig.SSHSecret).Should(Equal("aws-secret"))
+				Expect(dynamicConfig.InstanceTag).Should(BeEmpty()) // optional field
+				Expect(dynamicConfig.SudoCommands).Should(Equal("yum install -y docker"))
+			})
+
+			It("should parse multiple dynamic platforms of different cloud types successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					DynamicPlatforms:                      "linux/amd64,linux/s390x,linux/ppc64le",
+					"dynamic.linux-amd64.type":            "aws",
+					"dynamic.linux-amd64.max-instances":   "5",
+					"dynamic.linux-amd64.ssh-secret":      "aws-arm-secret",
+					"dynamic.linux-s390x.type":            "ibmz",
+					"dynamic.linux-s390x.max-instances":   "3",
+					"dynamic.linux-s390x.ssh-secret":      "ibm-s390x-secret",
+					"dynamic.linux-ppc64le.type":          "ibmp",
+					"dynamic.linux-ppc64le.max-instances": "2",
+					"dynamic.linux-ppc64le.ssh-secret":    "ibm-ppc64le-secret",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DynamicPlatforms).Should(HaveLen(3))
+
+				// Verify AWS platform
+				awsConfig := config.DynamicPlatforms["linux/amd64"]
+				Expect(awsConfig.Type).Should(Equal("aws"))
+				Expect(awsConfig.MaxInstances).Should(Equal(5))
+				Expect(awsConfig.InstanceTag).Should(BeEmpty())
+				Expect(awsConfig.AllocationTimeout).Should(Equal(int64(defaultAllocationTimeout)))
+				Expect(awsConfig.SSHSecret).Should(Equal("aws-arm-secret"))
+				Expect(awsConfig.SudoCommands).Should(BeEmpty())
+
+				// Verify IBM Z platform
+				ibmzConfig := config.DynamicPlatforms["linux/s390x"]
+				Expect(ibmzConfig.Type).Should(Equal("ibmz"))
+				Expect(ibmzConfig.MaxInstances).Should(Equal(3))
+				Expect(ibmzConfig.SSHSecret).Should(Equal("ibm-s390x-secret"))
+
+				// Verify IBM Power platform
+				ibmpConfig := config.DynamicPlatforms["linux/ppc64le"]
+				Expect(ibmpConfig.Type).Should(Equal("ibmp"))
+				Expect(ibmpConfig.MaxInstances).Should(Equal(2))
+				Expect(ibmpConfig.SSHSecret).Should(Equal("ibm-ppc64le-secret"))
+			})
+		})
+
+		When("parsing invalid dynamic platform configurations", func() {
+			DescribeTable("should return error for various invalid configurations",
+				func(ctx SpecContext, data map[string]string, expectedErrorSubstring string) {
+					_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+					Expect(err.Error()).Should(ContainSubstring(expectedErrorSubstring))
+				},
+				Entry("for invalid platform format",
+					map[string]string{
+						DynamicPlatforms: "invalid_platform",
+					},
+					"invalid dynamic platform 'invalid_platform'",
+				),
+				Entry("when type field is missing",
+					map[string]string{
+						DynamicPlatforms:                    "linux/amd64",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"type field is required",
+				),
+				Entry("when max-instances field is missing",
+					map[string]string{
+						DynamicPlatforms:                 "linux/amd64",
+						"dynamic.linux-amd64.type":       "aws",
+						"dynamic.linux-amd64.ssh-secret": "aws-secret",
+					},
+					"max-instances field is required",
+				),
+				Entry("when ssh-secret field is missing",
+					map[string]string{
+						DynamicPlatforms:                    "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+					},
+					"ssh-secret field is required",
+				),
+				Entry("for invalid max-instances value",
+					map[string]string{
+						DynamicPlatforms:                    "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "invalid",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid max-instances 'invalid'",
+				),
+				Entry("for max-instances exceeding limit",
+					map[string]string{
+						DynamicPlatforms:                    "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "999",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid max-instances '999'",
+				),
+				Entry("for allocation-timeout exceeding limit",
+					map[string]string{
+						DynamicPlatforms:                         "linux/amd64",
+						"dynamic.linux-amd64.type":               "aws",
+						"dynamic.linux-amd64.max-instances":      "10",
+						"dynamic.linux-amd64.allocation-timeout": "9999",
+						"dynamic.linux-amd64.ssh-secret":         "aws-secret",
+					},
+					"invalid allocation-timeout '9999'",
+				),
+				Entry("for invalid instance-tag value",
+					map[string]string{
+						DynamicPlatforms:                    "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.instance-tag":  "invalid-tag-format",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid instance-tag 'invalid-tag-format'",
+				),
+				Entry("for AWS platform with empty ssh-secret",
+					map[string]string{
+						DynamicPlatforms:                    "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.ssh-secret":    "   ",
+					},
+					"ssh-secret cannot be empty for AWS platforms",
+				),
+				Entry("for IBM platform with invalid ssh-secret",
+					map[string]string{
+						DynamicPlatforms:                    "linux/s390x",
+						"dynamic.linux-s390x.type":          "ibmz",
+						"dynamic.linux-s390x.max-instances": "3",
+						"dynamic.linux-s390x.ssh-secret":    "invalid-secret",
+					},
+					"invalid ssh-secret 'invalid-secret'",
+				),
+			)
+		})
+	})
+
+	// This section tests parsing and validation of dynamic pool platform configurations
+	Describe("The ParseAndValidate function with dynamic pool platforms", func() {
+
+		When("parsing valid dynamic pool platform configurations", func() {
+			It("should parse complete dynamic pool platform with all optional fields", func(ctx SpecContext) {
+				data := map[string]string{
+					DynamicPoolPlatforms:                         "linux-m2xlarge/amd64",
+					"dynamic.linux-m2xlarge-amd64.type":          "aws",
+					"dynamic.linux-m2xlarge-amd64.max-instances": "20",
+					"dynamic.linux-m2xlarge-amd64.concurrency":   "4",
+					"dynamic.linux-m2xlarge-amd64.max-age":       "60",
+					"dynamic.linux-m2xlarge-amd64.instance-tag":  "prod-amd64-m2xlarge",
+					"dynamic.linux-m2xlarge-amd64.ssh-secret":    "aws-pool-secret",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DynamicPoolPlatforms).Should(HaveKey("linux-m2xlarge/amd64"))
+
+				poolConfig := config.DynamicPoolPlatforms["linux-m2xlarge/amd64"]
+				Expect(poolConfig.Type).Should(Equal("aws"))
+				Expect(poolConfig.MaxInstances).Should(Equal(20))
+				Expect(poolConfig.Concurrency).Should(Equal(4))
+				Expect(poolConfig.MaxAge).Should(Equal(60))
+				Expect(poolConfig.InstanceTag).Should(Equal("prod-amd64-m2xlarge"))
+				Expect(poolConfig.SSHSecret).Should(Equal("aws-pool-secret"))
+			})
+
+			It("should parse multiple dynamic pool platforms of different cloud types successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					DynamicPoolPlatforms:                "linux/amd64,linux/arm64,linux/s390x",
+					"dynamic.linux-amd64.type":          "aws",
+					"dynamic.linux-amd64.max-instances": "20",
+					"dynamic.linux-amd64.concurrency":   "4",
+					"dynamic.linux-amd64.max-age":       "60",
+					"dynamic.linux-amd64.ssh-secret":    "aws-amd64-pool-secret",
+					"dynamic.linux-arm64.type":          "aws",
+					"dynamic.linux-arm64.max-instances": "15",
+					"dynamic.linux-arm64.concurrency":   "3",
+					"dynamic.linux-arm64.max-age":       "120",
+					"dynamic.linux-arm64.ssh-secret":    "aws-arm64-pool-secret",
+					"dynamic.linux-s390x.type":          "ibmz",
+					"dynamic.linux-s390x.max-instances": "5",
+					"dynamic.linux-s390x.concurrency":   "2",
+					"dynamic.linux-s390x.max-age":       "180",
+					"dynamic.linux-s390x.ssh-secret":    "ibm-s390x-pool-secret",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DynamicPoolPlatforms).Should(HaveLen(3))
+
+				// Verify AWS amd64 platform
+				amd64Config := config.DynamicPoolPlatforms["linux/amd64"]
+				Expect(amd64Config.Type).Should(Equal("aws"))
+				Expect(amd64Config.MaxInstances).Should(Equal(20))
+				Expect(amd64Config.Concurrency).Should(Equal(4))
+				Expect(amd64Config.MaxAge).Should(Equal(60))
+				Expect(amd64Config.SSHSecret).Should(Equal("aws-amd64-pool-secret"))
+
+				// Verify AWS arm64 platform
+				arm64Config := config.DynamicPoolPlatforms["linux/arm64"]
+				Expect(arm64Config.Type).Should(Equal("aws"))
+				Expect(arm64Config.MaxInstances).Should(Equal(15))
+				Expect(arm64Config.Concurrency).Should(Equal(3))
+				Expect(arm64Config.MaxAge).Should(Equal(120))
+				Expect(arm64Config.SSHSecret).Should(Equal("aws-arm64-pool-secret"))
+
+				// Verify IBM Z platform
+				ibmzConfig := config.DynamicPoolPlatforms["linux/s390x"]
+				Expect(ibmzConfig.Type).Should(Equal("ibmz"))
+				Expect(ibmzConfig.MaxInstances).Should(Equal(5))
+				Expect(ibmzConfig.Concurrency).Should(Equal(2))
+				Expect(ibmzConfig.MaxAge).Should(Equal(180))
+				Expect(ibmzConfig.SSHSecret).Should(Equal("ibm-s390x-pool-secret"))
+			})
+		})
+
+		When("parsing invalid dynamic pool platform configurations", func() {
+			DescribeTable("should return error for various invalid configurations",
+				func(ctx SpecContext, data map[string]string, expectedErrorSubstring string) {
+					_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+					Expect(err.Error()).Should(ContainSubstring(expectedErrorSubstring))
+				},
+				Entry("for invalid platform format",
+					map[string]string{
+						DynamicPoolPlatforms: "invalid_platform",
+						//"dynamic.linux-amd64.type": "aws",
+					},
+					"invalid dynamic pool platform 'invalid_platform'",
+				),
+				Entry("when type field is missing",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.concurrency":   "4",
+						"dynamic.linux-amd64.max-age":       "60",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"type field is required",
+				),
+				Entry("when max-instances field is missing",
+					map[string]string{
+						DynamicPoolPlatforms:              "linux/amd64",
+						"dynamic.linux-amd64.type":        "aws",
+						"dynamic.linux-amd64.concurrency": "4",
+						"dynamic.linux-amd64.max-age":     "60",
+						"dynamic.linux-amd64.ssh-secret":  "aws-secret",
+					},
+					"max-instances field is required",
+				),
+				Entry("when concurrency field is missing",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.max-age":       "60",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"concurrency field is required",
+				),
+				Entry("when max-age field is missing",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.concurrency":   "4",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"max-age field is required",
+				),
+				Entry("when ssh-secret field is missing",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.concurrency":   "4",
+						"dynamic.linux-amd64.max-age":       "60",
+					},
+					"ssh-secret field is required",
+				),
+				Entry("for invalid concurrency value",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.concurrency":   "invalid",
+						"dynamic.linux-amd64.max-age":       "60",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid concurrency 'invalid'",
+				),
+				Entry("for concurrency exceeding limit",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.concurrency":   "99",
+						"dynamic.linux-amd64.max-age":       "60",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid concurrency '99'",
+				),
+				Entry("for max-age exceeding limit",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/amd64",
+						"dynamic.linux-amd64.type":          "aws",
+						"dynamic.linux-amd64.max-instances": "10",
+						"dynamic.linux-amd64.concurrency":   "4",
+						"dynamic.linux-amd64.max-age":       "9999",
+						"dynamic.linux-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid max-age '9999'",
+				),
+				Entry("for invalid instance-tag value",
+					map[string]string{
+						DynamicPoolPlatforms:                         "linux-m2xlarge/amd64",
+						"dynamic.linux-m2xlarge-amd64.type":          "aws",
+						"dynamic.linux-m2xlarge-amd64.max-instances": "10",
+						"dynamic.linux-m2xlarge-amd64.concurrency":   "4",
+						"dynamic.linux-m2xlarge-amd64.max-age":       "60",
+						"dynamic.linux-m2xlarge-amd64.instance-tag":  "invalid-tag",
+						"dynamic.linux-m2xlarge-amd64.ssh-secret":    "aws-secret",
+					},
+					"invalid instance-tag 'invalid-tag'",
+				),
+				Entry("for IBM platform with invalid ssh-secret",
+					map[string]string{
+						DynamicPoolPlatforms:                "linux/s390x",
+						"dynamic.linux-s390x.type":          "ibmz",
+						"dynamic.linux-s390x.max-instances": "5",
+						"dynamic.linux-s390x.concurrency":   "2",
+						"dynamic.linux-s390x.max-age":       "180",
+						"dynamic.linux-s390x.ssh-secret":    "invalid-secret",
+					},
+					"invalid ssh-secret 'invalid-secret'",
+				),
+			)
+		})
+	})
+
+	// This section tests parsing and validation of static host configurations
+	Describe("The ParseAndValidate function with static platforms", func() {
+
+		When("parsing valid static host configurations", func() {
+			It("should parse a single static host with all required fields successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					"host.testhost1-s390x-static.address":     "127.0.0.1",
+					"host.testhost1-s390x-static.user":        "root",
+					"host.testhost1-s390x-static.platform":    "linux/s390x",
+					"host.testhost1-s390x-static.secret":      "test-s390x-static-secret",
+					"host.testhost1-s390x-static.concurrency": "4",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.StaticPlatforms).Should(HaveKey("testhost1-s390x-static"))
+				Expect(config.StaticPlatforms["testhost1-s390x-static"].Platform).Should(Equal("linux/s390x"))
+			})
+
+			It("should parse multiple static hosts for the same platform successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					"host.testhost1-s390x-static.address":     "127.0.0.1",
+					"host.testhost1-s390x-static.user":        "koko_hazamar",
+					"host.testhost1-s390x-static.platform":    "linux/s390x",
+					"host.testhost1-s390x-static.secret":      "test-s390x-static-secret",
+					"host.testhost1-s390x-static.concurrency": "4",
+					"host.testhost2-s390x-static.address":     "127.0.0.1",
+					"host.testhost2-s390x-static.user":        "moshe_kipod",
+					"host.testhost2-s390x-static.platform":    "linux/s390x",
+					"host.testhost2-s390x-static.secret":      "test-s390x-static-secret",
+					"host.testhost2-s390x-static.concurrency": "2",
+				}
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.StaticPlatforms).Should(HaveKey("testhost1-s390x-static"))
+				Expect(config.StaticPlatforms).Should(HaveKey("testhost2-s390x-static"))
+				Expect(config.StaticPlatforms["testhost1-s390x-static"].Platform).Should(Equal("linux/s390x"))
+				Expect(config.StaticPlatforms["testhost2-s390x-static"].Platform).Should(Equal("linux/s390x"))
+			})
+
+			It("should parse static hosts for different platforms successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					"host.linux-arm64-c4largeboom.address":     "127.0.0.1",
+					"host.linux-arm64-c4largeboom.user":        "root",
+					"host.linux-arm64-c4largeboom.platform":    "linux/arm64",
+					"host.linux-arm64-c4largeboom.secret":      "test-arm64-static-secret",
+					"host.linux-arm64-c4largeboom.concurrency": "4",
+					"host.testhost1-s390x-static.address":      "127.0.0.1",
+					"host.testhost1-s390x-static.user":         "ubuntu",
+					"host.testhost1-s390x-static.platform":     "linux/ppc64le",
+					"host.testhost1-s390x-static.secret":       "test-ppc64le-secret",
+					"host.testhost1-s390x-static.concurrency":  "2",
+				}
+
+				config, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(config.StaticPlatforms).Should(HaveLen(2))
+				Expect(config.StaticPlatforms).Should(HaveKey("linux-arm64-c4largeboom"))
+				Expect(config.StaticPlatforms).Should(HaveKey("testhost1-s390x-static"))
+				Expect(config.StaticPlatforms["linux-arm64-c4largeboom"].Platform).Should(Equal("linux/arm64"))
+				Expect(config.StaticPlatforms["testhost1-s390x-static"].Platform).Should(Equal("linux/ppc64le"))
+			})
+		})
+
+		When("parsing invalid static host configurations", func() {
+			It("should return error when address field is missing", func(ctx SpecContext) {
+				data := map[string]string{
+					"host.testhost1-s390x-static.user":        "root",
+					"host.testhost1-s390x-static.platform":    "linux/s390x",
+					"host.testhost1-s390x-static.secret":      "test-s390x-static-secret",
+					"host.testhost1-s390x-static.concurrency": "4",
+				}
+
+				_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(err.Error()).Should(ContainSubstring("address field is required"))
+			})
+
+			It("should return error for invalid IP address format", func(ctx SpecContext) {
+				data := map[string]string{
+					"host.testhost1-s390x-static.address":     "not-an-ip",
+					"host.testhost1-s390x-static.user":        "root",
+					"host.testhost1-s390x-static.platform":    "linux/s390x",
+					"host.testhost1-s390x-static.secret":      "test-s390x-static-secret",
+					"host.testhost1-s390x-static.concurrency": "4",
+				}
+
+				_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(err.Error()).Should(ContainSubstring("invalid address 'not-an-ip'"))
+			})
+
+			DescribeTable("should ignore malformed key patterns",
+				func(ctx SpecContext, data map[string]string, expectedHostCount int) {
+					config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+					Expect(config.StaticPlatforms).Should(HaveLen(expectedHostCount))
+				},
+				Entry("when keys without host prefix are present", map[string]string{
+					"host.validhost-s390x.address":     "127.0.0.1",
+					"host.validhost-s390x.user":        "koko_hazamar",
+					"other.config.value":               "something",
+					"host.validhost-s390x.platform":    "linux/s390x",
+					"host.validhost-s390x.secret":      "test-s390x-secret",
+					"host.validhost-s390x.concurrency": "2",
+				}, 1),
+				Entry("when keys with no dots after host prefix are present", map[string]string{
+					"host.validhost-s390x.address":     "127.0.0.1",
+					"host.validhost-s390x.user":        "moshe_kipod",
+					"host":                             "value",
+					"host.validhost-s390x.platform":    "linux/s390x",
+					"host.validhost-s390x.secret":      "test-s390x-secret",
+					"host.validhost-s390x.concurrency": "2",
+				}, 1),
+				Entry("when keys with only one dot after host prefix are present", map[string]string{
+					"host.validhost-s390x.address":     "127.0.0.1",
+					"host.validhost-s390x.user":        "steve",
+					"host.onlyhostname":                "value",
+					"host.validhost-s390x.platform":    "linux/s390x",
+					"host.validhost-s390x.secret":      "test-s390x-secret",
+					"host.validhost-s390x.concurrency": "2",
+				}, 1),
+			)
+		})
+	})
+
+	// This section tests parsing and validation of instance tagging configuration
+	Describe("The ParseAndValidate function with default or additional instance tags", func() {
+
+		When("parsing valid instance tag configurations", func() {
+			It("should parse default instance tag successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					DefaultInstanceTag: "prod-tag",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DefaultInstanceTag).Should(Equal("prod-tag"))
+			})
+
+			It("should parse single additional instance tag successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "env=production",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("env", "production"))
+			})
+
+			It("should parse multiple additional instance tags successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "env=production,team=backend,cost-center=engineering",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("env", "production"))
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("team", "backend"))
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("cost-center", "engineering"))
+			})
+
+			It("should parse additional instance tags with whitespace successfully", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "env=production , team=backend , cost-center=engineering",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.AdditionalInstanceTags).Should(HaveLen(3))
+			})
+
+			It("should split tag values at first equals sign only", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "equation=a",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("equation", "a"))
+			})
+
+			It("should return empty tags when fields are not present", func(ctx SpecContext) {
+				data := map[string]string{}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DefaultInstanceTag).Should(BeEmpty())
+				Expect(config.AdditionalInstanceTags).Should(BeEmpty())
+			})
+
+			It("should return empty tags when fields are empty strings", func(ctx SpecContext) {
+				data := map[string]string{
+					DefaultInstanceTag:     "",
+					AdditionalInstanceTags: "",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.DefaultInstanceTag).Should(BeEmpty())
+				Expect(config.AdditionalInstanceTags).Should(BeEmpty())
+			})
+		})
+
+		When("parsing invalid instance tag configurations", func() {
+			It("should return error for tag without equals sign", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "invalid-tag",
+				}
+
+				_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(err.Error()).Should(ContainSubstring("invalid additional instance tag format 'invalid-tag'"))
+			})
+
+			It("should accept tag with only key and empty value", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "key=",
+				}
+
+				config, _ := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("key", ""))
+			})
+
+			It("should return error when one tag in list is invalid", func(ctx SpecContext) {
+				data := map[string]string{
+					AdditionalInstanceTags: "env=production,invalid-tag,team=backend",
+				}
+
+				_, err := ParseAndValidate(ctx, nil, data, systemNamespace)
+				Expect(err.Error()).Should(ContainSubstring("invalid additional instance tag format 'invalid-tag'"))
+			})
+		})
+	})
+
+	// This section tests a comprehensive scenario, combining multiple platform types, generated using a host-config.yml
+	// taken from stone-prod-p02 before Maxim got to it )))) for extra-reality
+	Describe("The ParseAndValidate function with mixed platform configurations", func() {
+
+		When("parsing configurations with all platform types", func() {
+			It("should parse the production host-config.yaml successfully", func(ctx SpecContext) {
+				// using the same pattern as main->streamFileYamlToTektonObj()
+				bytes, err := os.ReadFile(filepath.Clean("../../../testing/sources/host-config.yaml"))
+				Expect(err).ShouldNot(HaveOccurred(), "Failed to read host-config.yaml")
+
+				scheme := runtime.NewScheme()
+				utilruntime.Must(corev1.AddToScheme(scheme))
+				codecFactory := serializer.NewCodecFactory(scheme)
+				decoder := codecFactory.UniversalDecoder(corev1.SchemeGroupVersion)
+				configMap := &corev1.ConfigMap{}
+				err = runtime.DecodeInto(decoder, bytes, configMap)
+				Expect(err).ShouldNot(HaveOccurred(), "Failed to decode host-config.yaml")
+				config, err := ParseAndValidate(ctx, nil, configMap.Data, systemNamespace)
+				Expect(err).ShouldNot(HaveOccurred(), "Failed to parse production host-config")
+
+				// Verify local platforms
+				Expect(config.LocalPlatforms).Should(ContainElements("linux/x86_64", "local", "localhost"))
+
+				// Verify dynamic platforms using a few key plafoms
+				Expect(config.DynamicPlatforms).Should(HaveKey("linux/arm64"))
+				Expect(config.DynamicPlatforms).Should(HaveKey("linux/amd64"))
+				Expect(config.DynamicPlatforms["linux/arm64"].Type).Should(Equal("aws"))
+				Expect(config.DynamicPlatforms["linux/arm64"].MaxInstances).Should(Equal(250))
+				Expect(config.DynamicPlatforms["linux/arm64"].InstanceTag).Should(Equal("prod-arm64"))
+
+				// Verify static platforms - count hosts by platform type
+				s390xCount := 0
+				ppc64leCount := 0
+				for _, host := range config.StaticPlatforms {
+					if host.Platform == "linux/s390x" {
+						s390xCount++
+					} else if host.Platform == "linux/ppc64le" {
+						ppc64leCount++
+					}
+				}
+				Expect(s390xCount).Should(Equal(10))
+				Expect(ppc64leCount).Should(Equal(5))
+
+				// Verify instance tags
+				Expect(config.DefaultInstanceTag).Should(Equal("rhtap-prod"))
+				Expect(config.AdditionalInstanceTags).Should(HaveLen(6))
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("Project", "Konflux"))
+				Expect(config.AdditionalInstanceTags).Should(HaveKeyWithValue("cost-center", "666"))
+			})
+		})
+	})
+})

--- a/pkg/reconciler/taskrun/provision_dynamic_test.go
+++ b/pkg/reconciler/taskrun/provision_dynamic_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Test Dynamic Host Provisioning", func() {
 		// 5. The user TaskRun completes.
 		// 6. The cloud instance is terminated as part of cleanup.
 		It("should allocate a cloud host correctly", func(ctx SpecContext) {
-			tr := runUserPipeline(ctx, client, reconciler, "test-dynamic-alloc")
+			tr := runDynamicHostPipeline(ctx, client, reconciler, "test-dynamic-alloc", "linux/arm64")
 			provision := getProvisionTaskRun(ctx, client, tr)
 			params := map[string]string{}
 			for _, i := range provision.Spec.Params {

--- a/pkg/reconciler/taskrun/provision_dynamicpool_test.go
+++ b/pkg/reconciler/taskrun/provision_dynamicpool_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Test Dynamic Pool Host Provisioning", func() {
 	// it gets assigned an instance from the pool, the provisioner succeeds,
 	// and after completion, the instance is returned to the pool (not terminated).
 	It("should allocate a cloud host with dynamic pool correctly", func(ctx SpecContext) {
-		tr := runUserPipeline(ctx, client, reconciler, "test-dyn-pool")
+		tr := runDynamicPoolPipeline(ctx, client, reconciler, "test-dyn-pool", "linux/arm64")
 		provision := getProvisionTaskRun(ctx, client, tr)
 		params := map[string]string{}
 		for _, i := range provision.Spec.Params {
@@ -78,7 +78,7 @@ var _ = Describe("Test Dynamic Pool Host Provisioning", func() {
 			Expect(len(cloudImpl.Instances)).Should(Equal(1))
 
 			// Start a user task. It should be assigned the single pre-existing instance.
-			userTask := runUserPipeline(ctx, client, reconciler, "test-dyn-pool-fail-1")
+			userTask := runDynamicPoolPipeline(ctx, client, reconciler, "test-dyn-pool-fail-1", "linux/arm64")
 			initialHost := userTask.Labels[AssignedHost]
 			Expect(initialHost).Should(Equal("preexisting-task"))
 
@@ -123,7 +123,7 @@ var _ = Describe("Test Dynamic Pool Host Provisioning", func() {
 			Expect(len(cloudImpl.Instances)).Should(Equal(2))
 
 			// Start a user task. It will be assigned one of the instances.
-			userTask := runUserPipeline(ctx, client, reconciler, "test-dyn-pool-all-fail")
+			userTask := runDynamicPoolPipeline(ctx, client, reconciler, "test-dyn-pool-all-fail", "linux/arm64")
 			host1 := userTask.Labels[AssignedHost]
 
 			// Fail the first provision task

--- a/pkg/reconciler/taskrun/provision_local_test.go
+++ b/pkg/reconciler/taskrun/provision_local_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Test Local Host Provisioning", func() {
 	// host "localhost" is correctly generated, and that all resources are
 	// cleaned up after the user TaskRun completes.
 	It("should allocate a local host correctly", func(ctx SpecContext) {
-		tr := runUserPipeline(ctx, client, reconciler, "test-local")
+		tr := runLocalHostPipeline(ctx, client, reconciler, "test-local", "linux/arm64")
 		ExpectNoProvisionTaskRun(ctx, client, tr)
 		secret := getSecret(ctx, client, tr)
 		Expect(secret.Data["error"]).Should(BeEmpty())

--- a/pkg/reconciler/taskrun/validation.go
+++ b/pkg/reconciler/taskrun/validation.go
@@ -1,16 +1,49 @@
 package taskrun
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	// alias for clarity, otherwise it'll look like aws.ActuallyWeThoughtAboutThisOne()
+	ec2Helpers "github.com/konflux-ci/multi-platform-controller/pkg/aws"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	errInvalidPlatformFormat    = errors.New("platform must be in format 'label/label' where each label follows Kubernetes RFC 1035 label name format")
 	errMissingPlatformParameter = errors.New("PLATFORM parameter not found in TaskRun parameters")
+	errInvalidNumericValue      = errors.New("value must be a valid integer between 1 and 100")
+	errInvalidIPFormat          = errors.New("value must be a valid IP address in dotted decimal notation")
+
+	// AWS resource validation errors - standardized to avoid exposing resource details in logs
+	errAWSClientCreation    = errors.New("failed to create AWS EC2 client")
+	errSecurityGroupInvalid = errors.New("security group not found or inaccessible")
+	errSubnetInvalid        = errors.New("subnet not found or inaccessible")
+	errKeyPairInvalid       = errors.New("key pair not found or inaccessible")
+	errAMIInvalid           = errors.New("AMI not found or not available")
+
+	// IBM resource validation errors
+	errIBMHostSecretEmpty            = errors.New("host secret value cannot be empty")
+	errIBMHostSecretPlatformMismatch = errors.New("host secret key and value must contain matching platform substring")
+
+	maxInstancesValue = 250
+	// Maximum allocation timeout value in seconds (20 minutes)
+	maxAllocationTimeout = 1200
+	// Maximum static host concurrency
+	maxStaticConcurrency = 8
+	// Maximum pool host age in minutes (24 hours)
+	maxPoolHostAge = 1440
+
+	// Cache flag for validated AWS resources to avoid repeated validation
+	mpcAWSResourcesValidated = false
 )
 
 // validatePlatformFormat validates a platform string according to the controller's rules
@@ -84,4 +117,344 @@ func extractPlatform(tr *tektonapi.TaskRun) (string, error) {
 		}
 	}
 	return "", errMissingPlatformParameter
+}
+
+// validateNumericValue validates a string represents a valid integer within the specified range
+// Validation rules:
+// - Must be a valid integer parseable by strconv.Atoi
+// - Must be between 1 and maxValue inclusive
+//
+// Parameters:
+// - value: The string value to validate
+// - maxValue: The maximum allowed value
+//
+// Returns:
+// - int: The validated integer value
+// - error: errInvalidNumericValue if value is invalid or out of range
+func validateNumericValue(value string, maxValue int) (int, error) {
+	num, err := strconv.Atoi(value)
+	if err != nil || num != max(0, min(num, maxValue)) {
+		return 0, errInvalidNumericValue
+	}
+	return num, nil
+}
+
+// validateMaxInstances validates a string represents a valid max-instances value
+// Uses the global maxInstancesValue as the upper limit
+//
+// Parameters:
+// - value: The string value to validate
+//
+// Returns:
+// - int: The validated integer value
+// - error: errInvalidNumericValue if value is invalid or out of range
+func validateMaxInstances(value string) (int, error) {
+	return validateNumericValue(value, maxInstancesValue)
+}
+
+// validateMaxAllocationTimeout validates a string represents a valid allocation timeout value
+// Uses the global maxAllocationTimeout as the upper limit
+//
+// Parameters:
+// - value: The string value to validate
+//
+// Returns:
+// - int: The validated integer value
+// - error: errInvalidNumericValue if value is invalid or out of range
+func validateMaxAllocationTimeout(value string) (int, error) {
+	return validateNumericValue(value, maxAllocationTimeout)
+}
+
+// obfuscateIP takes an IP address and returns it with the first three octets replaced with asterisks
+// Example: "192.168.1.1" becomes "***.***.***.1"
+func obfuscateIP(ip string) string {
+	parts := strings.Split(ip, ".")
+	return fmt.Sprintf("***.***.***.%s", parts[3])
+}
+
+// validateIP validates that a string represents a valid and reachable IP address
+// Uses Go's standard net.ParseIP function to validate IP format and attempts to connect to port 22.
+// This function assumes IPv4 addresses are being validated.
+// Validation rules:
+// - Must be a valid IPv4 address in dotted decimal notation (e.g., "192.168.1.1")
+// - Must be reachable on port 22 (SSH)
+//
+// Returns:
+// - nil if value is a valid and reachable IP address
+// - errInvalidIPFormat if value is not a valid IP address
+// - dynamic error if IP is valid but host is unreachable (includes obfuscated IP)
+func validateIP(value string) error {
+	ip := net.ParseIP(value)
+	if ip != nil {
+		// IP format is valid, now check reachability
+		if err := ec2Helpers.PingIPAddress(value); err != nil {
+			obfuscatedIP := obfuscateIP(value)
+			return fmt.Errorf("IP address is valid but host %s is unreachable", obfuscatedIP)
+		}
+		return nil
+	}
+	return errInvalidIPFormat
+}
+
+// validateIBMHostSecret validates IBM host secret configuration key-value pairs
+// Validation rules:
+// - Secret value cannot be empty
+// - Key and value must contain matching platform substring (either "s390x" or "ppc64le")
+// - No specific structure requirements - platform can appear anywhere in key or value
+//
+// Returns:
+// - nil if validation passes
+// - errIBMHostSecretEmpty if value is empty
+// - errIBMHostSecretPlatformMismatch if no matching platform substring found
+func validateIBMHostSecret(key, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return errIBMHostSecretEmpty
+	}
+
+	platforms := []string{"s390x", "ppc64le"}
+	for _, platform := range platforms {
+		if strings.Contains(key, platform) && strings.Contains(value, platform) {
+			return nil
+		}
+	}
+
+	return errIBMHostSecretPlatformMismatch
+}
+
+// validateDynamicInstanceTag validates dynamic AWS host instance-tag configuration
+// - Key format: "<host type>.<whatever>-<instance-type>-<platform>" (e.g., "dynamic.linux-m2xlarge-arm64")
+// - Value format: "<whatever>-<platform>-<instance-type>" (e.g., "prod-arm64-m2xlarge")
+// - Platform must match between key and value (arm64/amd64)
+// - Instance type must match between key and value
+//
+// Returns:
+//   - nil if validation passes
+//   - a descriptive error if the validation fails or if the inputs are malformed, and nil if
+//     the validation succeeds.
+func validateDynamicInstanceTag(key, value string) error {
+	// Parse and normalize the platform and instance type from the key, then from the key.
+	keyPlatform, keyInstanceType, err := parseDynamicHostInstanceTypeKey(key)
+	if err != nil {
+		return err
+	}
+
+	valuePlatform, valueInstanceType, err := parseDynamicHostInstanceTypValue(value)
+	if err != nil {
+		return err
+	}
+
+	// Platforms must be an exact match.
+	if keyPlatform != valuePlatform {
+		return fmt.Errorf("platform mismatch: key has '%s', value has '%s'", keyPlatform, valuePlatform)
+	}
+	// Instance types must be an exact match.
+	if keyInstanceType != valueInstanceType {
+		return fmt.Errorf("instance type mismatch: key has '%s', value has '%s'", keyInstanceType, valueInstanceType)
+	}
+	return nil
+}
+
+// parseDynamicHostInstanceTypeKey extracts the platform and instance type from the platform config name.
+// This function parses the simplified platform config name format and normalizes multi-part instance types.
+//
+// Parameters:
+// - platformConfigName: The platform config name (e.g., "linux-arm64" or "linux-d160-m4xlarge-arm64")
+//
+// Returns:
+// - string: The extracted platform
+// - string: The normalized instance type
+// - error: Parsing error if format is invalid
+func parseDynamicHostInstanceTypeKey(platformConfigName string) (platform, instanceType string, err error) {
+	firstDash := strings.Index(platformConfigName, "-")
+	lastDash := strings.LastIndex(platformConfigName, "-")
+
+	if firstDash == -1 || lastDash == -1 {
+		return "", "", fmt.Errorf("invalid platform config name: no dashes found in '%s'", platformConfigName)
+	}
+
+	if firstDash == lastDash {
+		// Simple platform with no instance type (e.g., "linux-arm64")
+		// Platform is everything after the dash, no instance type
+		platform = platformConfigName[lastDash+1:]
+		return platform, "", nil
+	}
+
+	// Platform is everything after the last dash.
+	platform = platformConfigName[lastDash+1:]
+	// Instance type is everything between the first and last dash.
+	instanceType = platformConfigName[firstDash+1 : lastDash]
+
+	// Normalize the instance type if it contains multiple parts
+	instanceParts := strings.Split(instanceType, "-")
+	if len(instanceParts) > 1 {
+		sort.Strings(instanceParts)
+		instanceType = strings.Join(instanceParts, "-")
+	}
+
+	return platform, instanceType, nil
+}
+
+// parseDynamicHostInstanceTypValue extracts the platform and instance type from the config value string
+// This function parses the config value format and normalizes multi-part instance types.
+//
+// Parameters:
+// - value: The config value string to parse
+//
+// Returns:
+// - string: The extracted platform
+// - string: The normalized instance type
+// - error: Parsing error if value format is invalid
+func parseDynamicHostInstanceTypValue(value string) (platform, instanceType string, err error) {
+	parts := strings.Split(value, "-")
+
+	// We need at least 2 parts - a prefix and a platform
+	// If there are only 2 parts, it's a simple value (e.g., "prod-arm64") with no instance type
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("invalid value format: must be '<prefix>-<platform>' or '<prefix>-<platform>-<instance_type>'")
+	}
+
+	// Platform is always the second part (index 1)
+	platform = parts[1]
+
+	// If there are only 2 parts, there's no instance type
+	if len(parts) == 2 {
+		return platform, "", nil
+	}
+
+	// Instance type is all remaining parts (from index 2 onwards)
+	instanceParts := parts[2:]
+
+	// Normalize if there's more than one component to the instance type
+	if len(instanceParts) > 1 {
+		sort.Strings(instanceParts)
+	}
+	instanceType = strings.Join(instanceParts, "-")
+
+	return platform, instanceType, nil
+}
+
+// AWSResourceValidationConfig holds configuration for AWS resource validation
+type AWSResourceValidationConfig struct {
+	Region          string
+	AMI             string
+	SecurityGroupId string
+	SubnetId        string
+	KeyName         string
+	AWSSecret       string
+	SystemNamespace string
+}
+
+// validateAWSResources validates AWS resources exist in the specified account/region
+// Validates security groups, subnets, and key pairs once (with caching), AMIs always validated
+// Returns error if any required resources are not found or cannot be accessed
+func validateAWSResources(ctx context.Context, kubeClient client.Client, config AWSResourceValidationConfig) error {
+	// Create AWS EC2 configuration so we can utilize
+	awsConfig := ec2Helpers.AWSEc2DynamicConfig{
+		Region:          config.Region,
+		Secret:          config.AWSSecret,
+		SystemNamespace: config.SystemNamespace,
+	}
+
+	// Create EC2 client once and reuse for all validations
+	ec2Client, err := awsConfig.CreateClient(kubeClient, ctx)
+	if err != nil {
+		return errAWSClientCreation
+	}
+
+	// Validate one-time resources (security groups, subnets, key pairs) only if not already validated
+	if !mpcAWSResourcesValidated {
+		// Validate security group (one-time validation)
+		if config.SecurityGroupId != "" {
+			if err := validateSecurityGroup(ctx, ec2Client, config.SecurityGroupId); err != nil {
+				return err
+			}
+		}
+
+		// Validate subnet (one-time validation)
+		if config.SubnetId != "" {
+			if err := validateSubnet(ctx, ec2Client, config.SubnetId); err != nil {
+				return err
+			}
+		}
+
+		// Validate key pair (one-time validation)
+		if config.KeyName != "" {
+			if err := validateKeyPair(ctx, ec2Client, config.KeyName); err != nil {
+				return err
+			}
+		}
+
+		// Mark these resources as validated
+		mpcAWSResourcesValidated = true
+	}
+
+	// Always validate AMI (no caching)
+	if config.AMI != "" {
+		if err := validateAMI(ctx, ec2Client, config.AMI); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateSecurityGroup validates that a security group exists
+func validateSecurityGroup(ctx context.Context, ec2Client *ec2.Client, securityGroupId string) error {
+	input := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []string{securityGroupId},
+	}
+
+	result, err := ec2Client.DescribeSecurityGroups(ctx, input)
+	if err != nil || len(result.SecurityGroups) == 0 {
+		return errSecurityGroupInvalid
+	}
+
+	return nil
+}
+
+// validateSubnet validates that a subnet exists
+func validateSubnet(ctx context.Context, ec2Client *ec2.Client, subnetId string) error {
+	input := &ec2.DescribeSubnetsInput{
+		SubnetIds: []string{subnetId},
+	}
+
+	result, err := ec2Client.DescribeSubnets(ctx, input)
+	if err != nil || len(result.Subnets) == 0 {
+		return errSubnetInvalid
+	}
+
+	return nil
+}
+
+// validateKeyPair validates that a key pair exists
+func validateKeyPair(ctx context.Context, ec2Client *ec2.Client, keyName string) error {
+	input := &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{keyName},
+	}
+
+	result, err := ec2Client.DescribeKeyPairs(ctx, input)
+	if err != nil || len(result.KeyPairs) == 0 {
+		return errKeyPairInvalid
+	}
+
+	return nil
+}
+
+// validateAMI validates that an AMI exists and is available
+func validateAMI(ctx context.Context, ec2Client *ec2.Client, amiId string) error {
+	input := &ec2.DescribeImagesInput{
+		ImageIds: []string{amiId},
+	}
+
+	result, err := ec2Client.DescribeImages(ctx, input)
+	if err != nil || len(result.Images) == 0 {
+		return errAMIInvalid
+	}
+
+	// Check if AMI is available
+	if string(result.Images[0].State) != "available" {
+		return errAMIInvalid
+	}
+
+	return nil
 }

--- a/pkg/reconciler/taskrun/validation_test.go
+++ b/pkg/reconciler/taskrun/validation_test.go
@@ -1,3 +1,7 @@
+// This file contains tests for the validation functions used by the TaskRun reconciler.
+// It covers platform format validation, numeric parameter validation (instance counts, timeouts),
+// IP address validation and obfuscation, IBM host secret validation, and dynamic instance tag
+// parsing and validation for AWS EC2 configurations.
 package taskrun
 
 import (
@@ -21,139 +25,372 @@ func createTrWithPlatform(platform string) *pipelinev1.TaskRun {
 	return tr
 }
 
-var _ = Describe("Platform Validation Tests", func() {
+var _ = Describe("Host Configuration Validation Tests", func() {
 
 	// This section tests the utility function responsible for extracting the
 	// target platform from a TaskRun's parameters.
-	Describe("Test extractPlatform function", func() {
-		It("should extract platform from TaskRun parameters successfully", func() {
-			tr := createTrWithPlatform("linux/amd64")
-			Expect(extractPlatform(tr)).To(Equal("linux/amd64"))
-		})
+	Describe("The extractPlatform function", func() {
 
-		It("should extract platform from TaskRun with multiple parameters", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/arm64")},
-						{Name: "ANOTHER_PARAM", Value: *pipelinev1.NewStructuredValues("another_value")},
-					},
-				},
-			}
-			Expect(extractPlatform(tr)).To(Equal("linux/arm64"))
-		})
+		When("extracting platform from TaskRun parameters", func() {
+			It("should extract platform from TaskRun parameters successfully", func() {
+				tr := createTrWithPlatform("linux/amd64")
+				Expect(extractPlatform(tr)).To(Equal("linux/amd64"))
+			})
 
-		It("should return first occurrence when multiple PlatformParam parameters exist", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/amd64")},
-						{Name: "MIDDLE_PARAM", Value: *pipelinev1.NewStructuredValues("middle_value")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/arm64")},
-						{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/s390x")},
-					},
-				},
-			}
-			Expect(extractPlatform(tr)).To(Equal("linux/amd64")) // Should return the first occurrence
-		})
-
-		It("should return error when PlatformParam parameter is missing", func() {
-			tr := &pipelinev1.TaskRun{
-				Spec: pipelinev1.TaskRunSpec{
-					Params: []pipelinev1.Param{
-						{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
-					},
-				},
-			}
-
-			_, err := extractPlatform(tr)
-			Expect(err).Should(MatchError(errMissingPlatformParameter))
-		})
-	})
-
-	// This section provides thorough unit tests for the platform format validation function.
-	// It is structured to test happy paths, sad paths, and special exceptions distinctly.
-	Describe("The validatePlatformFormat function", func() {
-
-		When("validating a correctly formatted platform string", func() {
-			DescribeTable("it should not return an error",
-				func(platform string) {
-					err := validatePlatformFormat(platform)
-					Expect(err).ShouldNot(HaveOccurred())
-				},
-				Entry("for linux/amd64", "linux/amd64"),
-				Entry("for linux/s390x", "linux/s390x"),
-			)
-		})
-
-		When("validating a special exception platform string", func() {
-			DescribeTable("it should not return an error",
-				func(platform string) {
-					err := validatePlatformFormat(platform)
-					Expect(err).ShouldNot(HaveOccurred())
-				},
-				Entry("for 'local'", "local"),
-				Entry("for 'localhost'", "localhost"),
-				Entry("for 'linux/x86_64'", "linux/x86_64"),
-			)
-		})
-
-		When("validating a malformed platform string", func() {
-			// A helper variable for the length test to keep the table entry clean.
-			longLabel := strings.Repeat("a", 64)
-
-			DescribeTable("it should return an invalid format error",
-				func(platform string) {
-					err := validatePlatformFormat(platform)
-					Expect(err).Should(MatchError(errInvalidPlatformFormat))
-				},
-				// --- Structural Errors ---
-				Entry("because it has too few parts", "linux"),
-				Entry("because it has too many parts", "linux/amd64/extra"),
-				Entry("because the first part is empty", "/amd64"),
-				Entry("because the second part is empty", "linux/"),
-				Entry("because it's just an empty string", ""),
-				Entry("because it has a trailing slash", "linux/amd64/"),
-				// --- DNS-1035 Label Violations ---
-				Entry("because it contains uppercase characters", "linux/AMD64"),
-				Entry("because it contains an underscore", "linux/amd_64"),
-				Entry("because a part starts with a hyphen", "-linux/amd64"),
-				Entry("because a part ends with a hyphen", "linux/amd64-"),
-				Entry("because a part is longer than 63 chars", fmt.Sprintf("linux/%s", longLabel)),
-			)
-		})
-	})
-
-	// This section tests the combined validation function
-	Describe("The validatePlatform function", func() {
-
-		When("the TaskRun contains a valid platform parameter", func() {
-			DescribeTable("it should return the platform and no error",
-				func(platformValue string) {
-					tr := createTrWithPlatform(platformValue)
-					Expect(validatePlatform(tr)).To(Equal(platformValue))
-				},
-				Entry("for a standard platform", "linux/amd64"),
-				Entry("for the 'linux/x86_64' exception", "linux/x86_64"),
-			)
-		})
-
-		When("the TaskRun contains an invalid or missing platform parameter", func() {
-			It("should return error when platform parameter is missing", func() {
+			It("should extract platform from TaskRun with multiple parameters", func() {
 				tr := &pipelinev1.TaskRun{
 					Spec: pipelinev1.TaskRunSpec{
-						Params: []pipelinev1.Param{},
+						Params: []pipelinev1.Param{
+							{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
+							{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/arm64")},
+							{Name: "ANOTHER_PARAM", Value: *pipelinev1.NewStructuredValues("another_value")},
+						},
 					},
 				}
-				Expect(validatePlatform(tr)).Error().To(MatchError(errMissingPlatformParameter))
+				Expect(extractPlatform(tr)).To(Equal("linux/arm64"))
+			})
+		})
+
+		When("handling edge cases with platform parameters", func() {
+			It("should return first occurrence when multiple PlatformParam parameters exist", func() {
+				tr := &pipelinev1.TaskRun{
+					Spec: pipelinev1.TaskRunSpec{
+						Params: []pipelinev1.Param{
+							{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
+							{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/amd64")},
+							{Name: "MIDDLE_PARAM", Value: *pipelinev1.NewStructuredValues("middle_value")},
+							{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/arm64")},
+							{Name: PlatformParam, Value: *pipelinev1.NewStructuredValues("linux/s390x")},
+						},
+					},
+				}
+				Expect(extractPlatform(tr)).To(Equal("linux/amd64")) // Should return the first occurrence
+			})
+		})
+
+		When("the PlatformParam parameter is missing", func() {
+			It("should return error when PlatformParam parameter is missing", func() {
+				tr := &pipelinev1.TaskRun{
+					Spec: pipelinev1.TaskRunSpec{
+						Params: []pipelinev1.Param{
+							{Name: "OTHER_PARAM", Value: *pipelinev1.NewStructuredValues("other_value")},
+						},
+					},
+				}
+
+				_, err := extractPlatform(tr)
+				Expect(err).Should(MatchError(errMissingPlatformParameter))
+			})
+		})
+
+		// This section provides thorough unit tests for the platform format validation function.
+		// It is structured to test happy paths, sad paths, and special exceptions distinctly.
+		Describe("The validatePlatformFormat function", func() {
+
+			When("validating a correctly formatted platform string", func() {
+				DescribeTable("it should not return an error",
+					func(platform string) {
+						err := validatePlatformFormat(platform)
+						Expect(err).ShouldNot(HaveOccurred())
+					},
+					Entry("for linux/amd64", "linux/amd64"),
+					Entry("for linux/s390x", "linux/s390x"),
+				)
 			})
 
-			It("should return error when platform parameter format is invalid", func() {
-				tr := createTrWithPlatform("koko_hazamar/moshe_ata_lo_kipod")
-				Expect(validatePlatform(tr)).Error().To(MatchError(errInvalidPlatformFormat))
+			When("validating a special exception platform string", func() {
+				DescribeTable("it should not return an error",
+					func(platform string) {
+						err := validatePlatformFormat(platform)
+						Expect(err).ShouldNot(HaveOccurred())
+					},
+					Entry("for 'local'", "local"),
+					Entry("for 'localhost'", "localhost"),
+					Entry("for 'linux/x86_64'", "linux/x86_64"),
+				)
 			})
+
+			When("validating a malformed platform string", func() {
+				// A helper variable for the length test to keep the table entry clean.
+				longLabel := strings.Repeat("a", 64)
+
+				DescribeTable("it should return an invalid format error",
+					func(platform string) {
+						err := validatePlatformFormat(platform)
+						Expect(err).Should(MatchError(errInvalidPlatformFormat))
+					},
+					// --- Structural Errors ---
+					Entry("because it has too few parts", "linux"),
+					Entry("because it has too many parts", "linux/amd64/extra"),
+					Entry("because the first part is empty", "/amd64"),
+					Entry("because the second part is empty", "linux/"),
+					Entry("because it's just an empty string", ""),
+					Entry("because it has a trailing slash", "linux/amd64/"),
+					// --- DNS-1035 Label Violations ---
+					Entry("because it contains uppercase characters", "linux/AMD64"),
+					Entry("because it contains an underscore", "linux/amd_64"),
+					Entry("because a part starts with a hyphen", "-linux/amd64"),
+					Entry("because a part ends with a hyphen", "linux/amd64-"),
+					Entry("because a part is longer than 63 chars", fmt.Sprintf("linux/%s", longLabel)),
+				)
+			})
+		})
+
+		// This section tests the combined validation function
+		Describe("The validatePlatform function", func() {
+
+			When("the TaskRun contains a valid platform parameter", func() {
+				DescribeTable("it should return the platform and no error",
+					func(platformValue string) {
+						tr := createTrWithPlatform(platformValue)
+						Expect(validatePlatform(tr)).To(Equal(platformValue))
+					},
+					Entry("for a standard platform", "linux/amd64"),
+					Entry("for the 'linux/x86_64' exception", "linux/x86_64"),
+				)
+			})
+
+			When("the TaskRun contains an invalid or missing platform parameter", func() {
+				It("should return error when platform parameter is missing", func() {
+					tr := &pipelinev1.TaskRun{
+						Spec: pipelinev1.TaskRunSpec{
+							Params: []pipelinev1.Param{},
+						},
+					}
+					Expect(validatePlatform(tr)).Error().To(MatchError(errMissingPlatformParameter))
+				})
+
+				It("should return error when platform parameter format is invalid", func() {
+					tr := createTrWithPlatform("koko_hazamar/moshe_ata_lo_kipod")
+					_, err := validatePlatform(tr)
+					Expect(err).Should(MatchError(errInvalidPlatformFormat))
+				})
+			})
+		})
+	})
+
+	// This section verifies validation of the numeric values that appear in host configurations.
+	Describe("The validateNumericValue function", func() {
+
+		When("validating numeric values within valid range", func() {
+			DescribeTable("it should return the parsed integer value",
+				func(value string, maxValue int, expected int) {
+					Expect(validateNumericValue(value, maxValue)).Should(Equal(expected))
+				},
+				Entry("with minimum value 0", "0", 100, 0),
+				Entry("with mid-range value", "50", 100, 50),
+				Entry("with maximum value", "100", 100, 100),
+				Entry("with very large maximum value", "1000", 1000000000, 1000),
+			)
+		})
+
+		When("validating numeric values outside valid range or invalid format", func() {
+			DescribeTable("it should return an error",
+				func(value string, maxValue int) {
+					_, err := validateNumericValue(value, maxValue)
+					Expect(err).Should(MatchError(errInvalidNumericValue))
+				},
+				Entry("with negative value", "-1", 100),
+				Entry("with value exceeding maximum", "101", 100),
+				Entry("with value far exceeding maximum", "100000", 100),
+				Entry("with non-numeric string", "abc", 100),
+				Entry("with empty string", "", 100),
+				Entry("with decimal value", "50.5", 100),
+				Entry("with value containing spaces", " 50 ", 100),
+			)
+		})
+	})
+
+	// This section verifies validation of the max-instances parameter for dynamic host allocation.
+	Describe("The validateMaxInstances function", func() {
+
+		When("validating max-instances values", func() {
+			DescribeTable("should accept valid instance count within range",
+				func(value string, expected int) {
+					Expect(validateMaxInstances(value)).Should(Equal(expected))
+				},
+				Entry("with instance count within range value 10", "10", 10),
+				Entry("with maximum allowed instances value", "250", 250),
+			)
+		})
+	})
+
+	// This section verifies validation of the allocation timeout parameter for host provisioning.
+	Describe("The validateMaxAllocationTimeout function", func() {
+
+		When("validating allocation timeout values values", func() {
+			DescribeTable("should accept valid timeout within range",
+				func(value string, expected int) {
+					Expect(validateMaxAllocationTimeout(value)).Should(Equal(expected))
+				},
+				Entry("with valid timeout within range value 10", "600", 600),
+				Entry("with maximum allowed timeout value", "1200", 1200),
+			)
+		})
+	})
+
+	// This section tests IP obfuscation for security purposes in logs and error messages.
+	Describe("The obfuscateIP function", func() {
+
+		When("obfuscating IP addresses", func() {
+			It("it should replace first three octets with asterisks", func() {
+				ip := "203.0.113.1"
+				expectedObfuscation := "***.***.***.1"
+				Expect(obfuscateIP(ip)).Should(Equal(expectedObfuscation))
+			})
+		})
+	})
+
+	// This spec only tests the IP format validation side of validateIP, since validateIP calls on
+	// ec2_helpers.PingIPAddress and it's pinging capabilities are already test-covered in ec2_helpers_test.go
+	Describe("The validateIP function", func() {
+
+		When("validating invalid IP formats", func() {
+			DescribeTable("it should return errInvalidIPFormat",
+				func(ip string) {
+					Expect(validateIP(ip)).Should(MatchError(errInvalidIPFormat))
+				},
+				Entry("with empty string", ""),
+				Entry("with invalid characters", "abc.def.ghi.jkl"),
+				Entry("with special characters", "abc.def.&.jkl"),
+				Entry("with incomplete octets", "203.0.1"),
+				Entry("with too many octets", "203.0.113.1.1"),
+				Entry("with non-numeric octets", "203.KokoHazamar.113.1"),
+				Entry("with octet exceeding 255", "203.0.113.256"),
+				Entry("with negative octets", "203.0.-113.1"),
+			)
+		})
+	})
+
+	// This section tests validation of IBM host secret configurations for s390x and ppc64le platforms.
+	Describe("The validateIBMHostSecret function", func() {
+
+		When("validating valid IBM host secrets", func() {
+			DescribeTable("it should accept matching platform substrings",
+				func(key, value string) {
+					Expect(validateIBMHostSecret(key, value)).ShouldNot(HaveOccurred())
+				},
+				Entry("with s390x in both key and value", "host-s390x-prod", "config-s390x-data"),
+				Entry("with ppc64le in both key and value", "host-ppc64le-dev", "setup-ppc64le-config"),
+				Entry("with IBM platform substring anywhere", "prod-s390x", "s390x-host-001"),
+				Entry("with IBM platform substring anywhere", "ppc64le-config", "host-ppc64le"),
+				Entry("with just IBM platform", "ppc64le", "ppc64le"),
+			)
+		})
+
+		When("validating invalid IBM host secrets", func() {
+			It("should return error when value is empty", func() {
+				err := validateIBMHostSecret("host-s390x", "")
+				Expect(err).Should(MatchError(errIBMHostSecretEmpty))
+			})
+
+			It("should return error when value is only whitespace", func() {
+				err := validateIBMHostSecret("host-s390x", "   ")
+				Expect(err).Should(MatchError(errIBMHostSecretEmpty))
+			})
+
+			DescribeTable("it should return error when platform substrings don't match",
+				func(key, value string) {
+					err := validateIBMHostSecret(key, value)
+					Expect(err).Should(MatchError(errIBMHostSecretPlatformMismatch))
+				},
+				Entry("with s390x in key but ppc64le in value", "host-s390x", "config-ppc64le"),
+				Entry("with ppc64le in key but s390x in value", "host-ppc64le", "config-s390x"),
+				Entry("with no platform in key", "host-prod", "config-s390x"),
+				Entry("with no platform in value", "host-s390x", "config-prod"),
+				Entry("with no platform in either", "host-prod", "config-dev"),
+			)
+		})
+	})
+
+	// This section tests parsing of dynamic host instance type configuration keys for AWS EC2.
+	Describe("The parseDynamicHostInstanceTypeKey function", func() {
+
+		When("parsing valid platform config names", func() {
+			DescribeTable("it should extract platform and instance type correctly",
+				func(configName, expectedPlatform, expectedInstanceType string) {
+					platform, instanceType, _ := parseDynamicHostInstanceTypeKey(configName)
+					Expect(platform).Should(Equal(expectedPlatform))
+					Expect(instanceType).Should(Equal(expectedInstanceType))
+				},
+				Entry("with simple format", "linux-m2xlarge-arm64", "arm64", "m2xlarge"),
+				Entry("with multi-part instance type", "linux-d160-m4xlarge-amd64", "amd64", "d160-m4xlarge"),
+				Entry("with multi-part instance type that requires normalization", "linux-m4xlarge-d160-arm64", "arm64", "d160-m4xlarge"),
+			)
+		})
+
+		When("parsing invalid config key strings", func() {
+			DescribeTable("it should return an error",
+				func(value string) {
+					_, _, err := parseDynamicHostInstanceTypValue(value)
+					Expect(err).Should(HaveOccurred())
+				},
+				Entry("with too few parts", "m2xlargeamd64"),
+				Entry("with empty string", ""),
+			)
+		})
+	})
+
+	// This section tests parsing of dynamic host instance type configuration values for AWS EC2.
+	Describe("The parseDynamicHostInstanceTypValue function", func() {
+
+		When("parsing valid config value strings", func() {
+			DescribeTable("it should extract platform and instance type correctly",
+				func(value, expectedPlatform, expectedInstanceType string) {
+					platform, instanceType, _ := parseDynamicHostInstanceTypValue(value)
+					Expect(platform).Should(Equal(expectedPlatform))
+					Expect(instanceType).Should(Equal(expectedInstanceType))
+				},
+				Entry("with simple format", "prod-arm64-m2xlarge", "arm64", "m2xlarge"),
+				Entry("with multi-part instance type", "prod-amd64-d160-m4xlarge", "amd64", "d160-m4xlarge"),
+				Entry("with multi-part instance type that requires normalization", "prod-amd64-m4xlarge-d160", "amd64", "d160-m4xlarge"),
+			)
+		})
+
+		When("parsing invalid config value strings", func() {
+			DescribeTable("it should return an error",
+				func(value string) {
+					_, _, err := parseDynamicHostInstanceTypValue(value)
+					Expect(err).Should(HaveOccurred())
+				},
+				Entry("with too few parts", "prodarm64"),
+				Entry("with empty string", ""),
+			)
+		})
+	})
+
+	// This section tests end-to-end validation of dynamic instance tag configurations for AWS EC2.
+	Describe("The validateDynamicInstanceTag function", func() {
+
+		When("validating matching platform and instance type configurations", func() {
+			DescribeTable("it should accept valid key-value pairs",
+				func(key, value string) {
+					Expect(validateDynamicInstanceTag(key, value)).ShouldNot(HaveOccurred())
+				},
+				Entry("with matching arm64 platform and instance type", "linux-m2xlarge-arm64", "prod-arm64-m2xlarge"),
+				Entry("with multi-part instance type in correct order", "linux-d160-m4xlarge-arm64", "prod-arm64-d160-m4xlarge"),
+				Entry("with multi-part instance type in different order", "linux-m4xlarge-d160-arm64", "prod-arm64-d160-m4xlarge"),
+			)
+		})
+
+		When("validating mismatched configurations", func() {
+			It("should return error when platforms don't match", func() {
+				Expect(validateDynamicInstanceTag("linux-m2xlarge-arm64", "prod-amd64-m2xlarge").Error()).Should(ContainSubstring("platform mismatch"))
+			})
+
+			It("should return error when instance types don't match", func() {
+				Expect(validateDynamicInstanceTag("linux-m2xlarge-arm64", "prod-arm64-t3large").Error()).Should(ContainSubstring("instance type mismatch"))
+			})
+		})
+
+		When("validating invalid key or value formats", func() {
+			DescribeTable("it should return error when key or value formats are invalid",
+				func(key, value string) {
+					Expect(Expect(validateDynamicInstanceTag(key, value)).Should(HaveOccurred()))
+				},
+				Entry("with matching arm64 platform and instance type", "invalid-format", "prod-arm64-m2xlarge"),
+				Entry("with multi-part instance type in correct order", "linux-m2xlarge-arm64", "invalid-format"),
+			)
 		})
 	})
 })

--- a/testing/sources/host-config.yaml
+++ b/testing/sources/host-config.yaml
@@ -1,0 +1,654 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    build.appstudio.redhat.com/multi-platform-config: hosts
+  name: host-config
+  namespace: multi-platform-controller
+data:
+  local-platforms: "\
+    linux/x86_64,\
+    local,\
+    localhost,\
+    "
+  dynamic-platforms: "\
+    linux/arm64,\
+    linux/amd64,\
+    linux-mlarge/amd64,\
+    linux-mlarge/arm64,\
+    linux-mxlarge/amd64,\
+    linux-mxlarge/arm64,\
+    linux-m2xlarge/amd64,\
+    linux-m2xlarge/arm64,\
+    linux-d160-m2xlarge/amd64,\
+    linux-d160-m2xlarge/arm64,\
+    linux-m4xlarge/amd64,\
+    linux-m4xlarge/arm64,\
+    linux-d160-m4xlarge/amd64,\
+    linux-d160-m4xlarge/arm64,\
+    linux-m8xlarge/amd64,\
+    linux-m8xlarge/arm64,\
+    linux-d160-m8xlarge/amd64,\
+    linux-d160-m8xlarge/arm64,\
+    linux-c6gd2xlarge/arm64,\
+    linux-cxlarge/amd64,\
+    linux-cxlarge/arm64,\
+    linux-c2xlarge/amd64,\
+    linux-c2xlarge/arm64,\
+    linux-c4xlarge/amd64,\
+    linux-c4xlarge/arm64,\
+    linux-c8xlarge/amd64,\
+    linux-c8xlarge/arm64,\
+    linux-g6xlarge/amd64,\
+    linux-root/arm64,\
+    linux-root/amd64,\
+    linux-fast/amd64,\
+    linux-extra-fast/amd64\
+    "
+  instance-tag: "rhtap-prod"
+
+  additional-instance-tags: "\
+    Project=Konflux,\
+    Owner=konflux-test-string,\
+    ManagedBy=Konflux Infra Team,\
+    app-code=ASSH-001,\
+    service-phase=Production,\
+    cost-center=666\
+    "
+
+  # cpu:memory (1:4)
+  dynamic.linux-arm64.type: "aws"
+  dynamic.linux-arm64.region: "us-east-1"
+  dynamic.linux-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-arm64.instance-type: "m6g.large"
+  dynamic.linux-arm64.instance-tag: "prod-arm64"
+  dynamic.linux-arm64.key-name: "konflux-test-string"
+  dynamic.linux-arm64.aws-secret: "aws-account"
+  dynamic.linux-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-arm64.max-instances: "250"
+  dynamic.linux-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-mlarge-arm64.type: "aws"
+  dynamic.linux-mlarge-arm64.region: "us-east-1"
+  dynamic.linux-mlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-mlarge-arm64.instance-type: "m6g.large"
+  dynamic.linux-mlarge-arm64.instance-tag: "prod-arm64-mlarge"
+  dynamic.linux-mlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-mlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-mlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-mlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-mlarge-arm64.max-instances: "250"
+  dynamic.linux-mlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-mxlarge-arm64.type: "aws"
+  dynamic.linux-mxlarge-arm64.region: "us-east-1"
+  dynamic.linux-mxlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-mxlarge-arm64.instance-type: "m6g.xlarge"
+  dynamic.linux-mxlarge-arm64.instance-tag: "prod-arm64-mxlarge"
+  dynamic.linux-mxlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-mxlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-mxlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-mxlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-mxlarge-arm64.max-instances: "250"
+  dynamic.linux-mxlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-m2xlarge-arm64.type: "aws"
+  dynamic.linux-m2xlarge-arm64.region: "us-east-1"
+  dynamic.linux-m2xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-m2xlarge-arm64.instance-type: "m6g.2xlarge"
+  dynamic.linux-m2xlarge-arm64.instance-tag: "prod-arm64-m2xlarge"
+  dynamic.linux-m2xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-m2xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-m2xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-m2xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-m2xlarge-arm64.max-instances: "250"
+  dynamic.linux-m2xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m2xlarge-arm64.type: "aws"
+  dynamic.linux-d160-m2xlarge-arm64.region: "us-east-1"
+  dynamic.linux-d160-m2xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: "m6g.2xlarge"
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: "prod-arm64-m2xlarge-d160"
+  dynamic.linux-d160-m2xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "250"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+
+  dynamic.linux-m4xlarge-arm64.type: "aws"
+  dynamic.linux-m4xlarge-arm64.region: "us-east-1"
+  dynamic.linux-m4xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-m4xlarge-arm64.instance-type: "m6g.4xlarge"
+  dynamic.linux-m4xlarge-arm64.instance-tag: "prod-arm64-m4xlarge"
+  dynamic.linux-m4xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-m4xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-m4xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-m4xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-m4xlarge-arm64.max-instances: "250"
+  dynamic.linux-m4xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-c6gd2xlarge-arm64.type: "aws"
+  dynamic.linux-c6gd2xlarge-arm64.region: "us-east-1"
+  dynamic.linux-c6gd2xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-c6gd2xlarge-arm64.instance-type: "c6gd.2xlarge"
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: "prod-arm64-c6gd2xlarge"
+  dynamic.linux-c6gd2xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-c6gd2xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-c6gd2xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c6gd2xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "250"
+  dynamic.linux-c6gd2xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c6gd2xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-c6gd2xlarge-arm64.user-data: |-
+    Content-Type: multipart/mixed; boundary="//"
+    MIME-Version: 1.0
+
+    --//
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nisl sem, vehicula sed turpis sit amet, iaculis 
+    vehicula urna. Integer faucibus diam at neque dignissim tincidunt. Vestibulum suscipit est id ante consequat, vel 
+    tempor metus eleifend. Nullam sem nibh, tincidunt nec laoreet ac, aliquet et arcu. Sed ultrices, ipsum sed 
+    condimentum faucibus, leo est semper sapien, vel vehicula massa felis in ipsum. Donec porttitor aliquam fringilla. 
+    Morbi blandit vestibulum felis vel elementum. Cras velit lorem, tempus vitae viverra ac, vulputate non sapien. 
+    Vivamus gravida turpis urna, vitae laoreet ipsum bibendum vel. Nam vestibulum vehicula dignissim.
+    
+    Suspendisse lobortis magna quis massa auctor varius. Ut luctus nunc ac fermentum tincidunt. Nam lobortis, turpis nec 
+    tempor dapibus, velit nulla tempor neque, nec pulvinar lorem arcu feugiat arcu. Vestibulum sit amet rhoncus lectus. 
+    Donec lobortis accumsan tristique. Cras varius, odio sit amet posuere consequat, velit ligula sodales metus, et 
+    eleifend sem lorem sit amet quam. Etiam et orci et sapien blandit condimentum. Donec nisi lorem, pulvinar eget leo 
+    vel, convallis fringilla leo. Aenean sodales aliquam ipsum, eget ornare magna maximus at. Mauris condimentum commodo 
+    ipsum in ullamcorper. Maecenas molestie velit tincidunt, condimentum sem at, varius sapien. Pellentesque feugiat 
+    velit ipsum.
+    
+    Cras dapibus dolor a metus consequat, sit amet bibendum metus aliquet. Pellentesque urna lorem, finibus id justo 
+    eget, tristique molestie augue. Nulla aliquet fringilla odio. Fusce egestas varius mi sed interdum. Fusce a diam 
+    laoreet, viverra eros et, venenatis sem. Praesent euismod id turpis eget fringilla. Quisque et neque pulvinar, 
+    tempor arcu et, ullamcorper nibh.
+    
+    Etiam ut pellentesque ipsum. Morbi varius est eget arcu imperdiet, eu placerat lacus vestibulum. Integer dapibus ac 
+    elit eget blandit. Integer iaculis eros quis libero suscipit imperdiet. Nam dignissim faucibus neque dignissim 
+    vehicula. Vivamus sit amet diam ornare dolor congue rhoncus in quis sapien. Fusce dignissim sagittis ante at varius. 
+    Curabitur urna leo, pharetra sed enim sit amet, tempus faucibus urna. Fusce ut lorem ut mi imperdiet ullamcorper non 
+    non lectus. Etiam interdum nisl nec enim commodo fermentum. Curabitur sed pellentesque turpis. Vivamus efficitur 
+    felis eu lacus blandit, sed interdum nunc placerat. Nullam maximus tellus augue, et blandit mi pretium non. Proin 
+    sed mattis sem. Mauris pellentesque dolor rutrum augue elementum condimentum. Aenean scelerisque, magna non suscipit 
+    hendrerit, tortor magna aliquam erat, quis fringilla elit massa a ipsum.
+    
+    In in eros mi. Curabitur iaculis eros et ante finibus, pellentesque porta elit consectetur. Nulla scelerisque non 
+    leo at pretium. Nullam sagittis purus vitae risus consectetur, eu malesuada justo ornare. Donec eget condimentum 
+    nisl. Duis vitae velit at arcu faucibus aliquet. Nullam tempor arcu a odio iaculis mollis sit amet a tellus. In hac 
+    habitasse platea dictumst.
+    --//--
+
+  # same as m4xlarge-arm64 but with 160G disk
+  dynamic.linux-d160-m4xlarge-arm64.type: "aws"
+  dynamic.linux-d160-m4xlarge-arm64.region: "us-east-1"
+  dynamic.linux-d160-m4xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: "m6g.4xlarge"
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: "prod-arm64-d160-m4xlarge"
+  dynamic.linux-d160-m4xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "250"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
+
+  dynamic.linux-m8xlarge-arm64.type: "aws"
+  dynamic.linux-m8xlarge-arm64.region: "us-east-1"
+  dynamic.linux-m8xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-m8xlarge-arm64.instance-type: "m6g.8xlarge"
+  dynamic.linux-m8xlarge-arm64.instance-tag: "prod-arm64-m8xlarge"
+  dynamic.linux-m8xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-m8xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-m8xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-m8xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-m8xlarge-arm64.max-instances: "250"
+  dynamic.linux-m8xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m8xlarge-arm64.type: "aws"
+  dynamic.linux-d160-m8xlarge-arm64.region: "us-east-1"
+  dynamic.linux-d160-m8xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: "m6g.8xlarge"
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: "prod-arm64-m8xlarge-d160"
+  dynamic.linux-d160-m8xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "250"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
+
+  dynamic.linux-amd64.type: "aws"
+  dynamic.linux-amd64.region: "us-east-1"
+  dynamic.linux-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-amd64.instance-type: "m6a.large"
+  dynamic.linux-amd64.instance-tag: "prod-amd64"
+  dynamic.linux-amd64.key-name: "konflux-test-string"
+  dynamic.linux-amd64.aws-secret: "aws-account"
+  dynamic.linux-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-amd64.max-instances: "250"
+  dynamic.linux-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-mlarge-amd64.type: "aws"
+  dynamic.linux-mlarge-amd64.region: "us-east-1"
+  dynamic.linux-mlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-mlarge-amd64.instance-type: "m6a.large"
+  dynamic.linux-mlarge-amd64.instance-tag: "prod-amd64-mlarge"
+  dynamic.linux-mlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-mlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-mlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-mlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-mlarge-amd64.max-instances: "250"
+  dynamic.linux-mlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-mxlarge-amd64.type: "aws"
+  dynamic.linux-mxlarge-amd64.region: "us-east-1"
+  dynamic.linux-mxlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-mxlarge-amd64.instance-type: "m6a.xlarge"
+  dynamic.linux-mxlarge-amd64.instance-tag: "prod-amd64-mxlarge"
+  dynamic.linux-mxlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-mxlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-mxlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-mxlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-mxlarge-amd64.max-instances: "250"
+  dynamic.linux-mxlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-m2xlarge-amd64.type: "aws"
+  dynamic.linux-m2xlarge-amd64.region: "us-east-1"
+  dynamic.linux-m2xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-m2xlarge-amd64.instance-type: "m6a.2xlarge"
+  dynamic.linux-m2xlarge-amd64.instance-tag: "prod-amd64-m2xlarge"
+  dynamic.linux-m2xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-m2xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-m2xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-m2xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-m2xlarge-amd64.max-instances: "250"
+  dynamic.linux-m2xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m2xlarge-amd64.type: "aws"
+  dynamic.linux-d160-m2xlarge-amd64.region: "us-east-1"
+  dynamic.linux-d160-m2xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: "m6a.2xlarge"
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: "prod-amd64-m2xlarge-d160"
+  dynamic.linux-d160-m2xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "250"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+
+  dynamic.linux-m4xlarge-amd64.type: "aws"
+  dynamic.linux-m4xlarge-amd64.region: "us-east-1"
+  dynamic.linux-m4xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-m4xlarge-amd64.instance-type: "m6a.4xlarge"
+  dynamic.linux-m4xlarge-amd64.instance-tag: "prod-amd64-m4xlarge"
+  dynamic.linux-m4xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-m4xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-m4xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-m4xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-m4xlarge-amd64.max-instances: "250"
+  dynamic.linux-m4xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
+
+  # same as m4xlarge-amd64 bug 160G disk
+  dynamic.linux-d160-m4xlarge-amd64.type: "aws"
+  dynamic.linux-d160-m4xlarge-amd64.region: "us-east-1"
+  dynamic.linux-d160-m4xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-d160-m4xlarge-amd64.instance-type: "m6a.4xlarge"
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: "prod-amd64-m4xlarge-d160"
+  dynamic.linux-d160-m4xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-d160-m4xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-d160-m4xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-d160-m4xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "250"
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m4xlarge-amd64.disk: "160"
+
+  dynamic.linux-m8xlarge-amd64.type: "aws"
+  dynamic.linux-m8xlarge-amd64.region: "us-east-1"
+  dynamic.linux-m8xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-m8xlarge-amd64.instance-type: "m6a.8xlarge"
+  dynamic.linux-m8xlarge-amd64.instance-tag: "prod-amd64-m8xlarge"
+  dynamic.linux-m8xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-m8xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-m8xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-m8xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-m8xlarge-amd64.max-instances: "250"
+  dynamic.linux-m8xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m8xlarge-amd64.type: "aws"
+  dynamic.linux-d160-m8xlarge-amd64.region: "us-east-1"
+  dynamic.linux-d160-m8xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: "m6a.8xlarge"
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: "prod-amd64-m8xlarge-d160"
+  dynamic.linux-d160-m8xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "250"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
+
+  dynamic.linux-fast-amd64.type: "aws"
+  dynamic.linux-fast-amd64.region: "us-east-1"
+  dynamic.linux-fast-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-fast-amd64.instance-type: "c7a.8xlarge"
+  dynamic.linux-fast-amd64.instance-tag: "prod-amd64-fast"
+  dynamic.linux-fast-amd64.key-name: "konflux-test-string"
+  dynamic.linux-fast-amd64.aws-secret: "aws-account"
+  dynamic.linux-fast-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-fast-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-fast-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-fast-amd64.max-instances: "250"
+  dynamic.linux-fast-amd64.disk: "200"
+
+  dynamic.linux-extra-fast-amd64.type: "aws"
+  dynamic.linux-extra-fast-amd64.region: "us-east-1"
+  dynamic.linux-extra-fast-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-extra-fast-amd64.instance-type: "c7a.12xlarge"
+  dynamic.linux-extra-fast-amd64.instance-tag: "prod-amd64-extra-fast"
+  dynamic.linux-extra-fast-amd64.key-name: "konflux-test-string"
+  dynamic.linux-extra-fast-amd64.aws-secret: "aws-account"
+  dynamic.linux-extra-fast-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-extra-fast-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-extra-fast-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-extra-fast-amd64.max-instances: "250"
+  dynamic.linux-extra-fast-amd64.disk: "200"
+
+  # cpu:memory (1:2)
+  dynamic.linux-cxlarge-arm64.type: "aws"
+  dynamic.linux-cxlarge-arm64.region: "us-east-1"
+  dynamic.linux-cxlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-cxlarge-arm64.instance-type: "c6g.xlarge"
+  dynamic.linux-cxlarge-arm64.instance-tag: "prod-arm64-cxlarge"
+  dynamic.linux-cxlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-cxlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-cxlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-cxlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-cxlarge-arm64.max-instances: "250"
+  dynamic.linux-cxlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-c2xlarge-arm64.type: "aws"
+  dynamic.linux-c2xlarge-arm64.region: "us-east-1"
+  dynamic.linux-c2xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-c2xlarge-arm64.instance-type: "c6g.2xlarge"
+  dynamic.linux-c2xlarge-arm64.instance-tag: "prod-arm64-c2xlarge"
+  dynamic.linux-c2xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-c2xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-c2xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c2xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c2xlarge-arm64.max-instances: "250"
+  dynamic.linux-c2xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-c4xlarge-arm64.type: "aws"
+  dynamic.linux-c4xlarge-arm64.region: "us-east-1"
+  dynamic.linux-c4xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-c4xlarge-arm64.instance-type: "c6g.4xlarge"
+  dynamic.linux-c4xlarge-arm64.instance-tag: "prod-arm64-c4xlarge"
+  dynamic.linux-c4xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-c4xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-c4xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c4xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c4xlarge-arm64.max-instances: "250"
+  dynamic.linux-c4xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-c8xlarge-arm64.type: "aws"
+  dynamic.linux-c8xlarge-arm64.region: "us-east-1"
+  dynamic.linux-c8xlarge-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-c8xlarge-arm64.instance-type: "c6g.8xlarge"
+  dynamic.linux-c8xlarge-arm64.instance-tag: "prod-arm64-c8xlarge"
+  dynamic.linux-c8xlarge-arm64.key-name: "konflux-test-string"
+  dynamic.linux-c8xlarge-arm64.aws-secret: "aws-account"
+  dynamic.linux-c8xlarge-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c8xlarge-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c8xlarge-arm64.max-instances: "250"
+  dynamic.linux-c8xlarge-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-cxlarge-amd64.type: "aws"
+  dynamic.linux-cxlarge-amd64.region: "us-east-1"
+  dynamic.linux-cxlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-cxlarge-amd64.instance-type: "c6a.xlarge"
+  dynamic.linux-cxlarge-amd64.instance-tag: "prod-amd64-cxlarge"
+  dynamic.linux-cxlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-cxlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-cxlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-cxlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-cxlarge-amd64.max-instances: "250"
+  dynamic.linux-cxlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-c2xlarge-amd64.type: "aws"
+  dynamic.linux-c2xlarge-amd64.region: "us-east-1"
+  dynamic.linux-c2xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-c2xlarge-amd64.instance-type: "c6a.2xlarge"
+  dynamic.linux-c2xlarge-amd64.instance-tag: "prod-amd64-c2xlarge"
+  dynamic.linux-c2xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-c2xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-c2xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c2xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c2xlarge-amd64.max-instances: "250"
+  dynamic.linux-c2xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-c4xlarge-amd64.type: "aws"
+  dynamic.linux-c4xlarge-amd64.region: "us-east-1"
+  dynamic.linux-c4xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-c4xlarge-amd64.instance-type: "c6a.4xlarge"
+  dynamic.linux-c4xlarge-amd64.instance-tag: "prod-amd64-c4xlarge"
+  dynamic.linux-c4xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-c4xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-c4xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c4xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c4xlarge-amd64.max-instances: "250"
+  dynamic.linux-c4xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-c8xlarge-amd64.type: "aws"
+  dynamic.linux-c8xlarge-amd64.region: "us-east-1"
+  dynamic.linux-c8xlarge-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-c8xlarge-amd64.instance-type: "c6a.8xlarge"
+  dynamic.linux-c8xlarge-amd64.instance-tag: "prod-amd64-c8xlarge"
+  dynamic.linux-c8xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-c8xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-c8xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-c8xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-c8xlarge-amd64.max-instances: "250"
+  dynamic.linux-c8xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-root-arm64.type: "aws"
+  dynamic.linux-root-arm64.region: "us-east-1"
+  dynamic.linux-root-arm64.ami: "ami-0xxxxxxxxxxxxb"
+  dynamic.linux-root-arm64.instance-type: "m6g.large"
+  dynamic.linux-root-arm64.instance-tag: "prod-arm64-root"
+  dynamic.linux-root-arm64.key-name: "konflux-test-string"
+  dynamic.linux-root-arm64.aws-secret: "aws-account"
+  dynamic.linux-root-arm64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-root-arm64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-root-arm64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-root-arm64.max-instances: "250"
+  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
+  dynamic.linux-root-arm64.disk: "200"
+  dynamic.linux-root-arm64.iops: "16000"
+  dynamic.linux-root-arm64.throughput: "1000"
+
+  dynamic.linux-root-amd64.type: "aws"
+  dynamic.linux-root-amd64.region: "us-east-1"
+  dynamic.linux-root-amd64.ami: "ami-0xxxxxxxxxxxx2"
+  dynamic.linux-root-amd64.instance-type: "m6idn.2xlarge"
+  dynamic.linux-root-amd64.instance-tag: "prod-amd64-root"
+  dynamic.linux-root-amd64.key-name: "konflux-test-string"
+  dynamic.linux-root-amd64.aws-secret: "aws-account"
+  dynamic.linux-root-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-root-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-root-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-root-amd64.max-instances: "250"
+  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
+  dynamic.linux-root-amd64.user-data: |-
+    Content-Type: multipart/mixed; boundary="//"
+    MIME-Version: 1.0
+    
+    --//
+    All day in the streets
+    Wandering between shops
+    This is my job
+    This is my livelihood
+    
+    Inspector, I'm unloading goods
+    I'll be right back
+    Inspector, I'm unloading goods
+    Don't give me a ticket
+    Be a man with me, my brother
+    I'm also Mizrahi
+    
+    Every morning I go out to work
+    To unload the goods
+    Municipality inspectors, I ask for forgiveness
+    I'm unloading goods
+    
+    Inspector, I'm unloading goods...
+  
+    --//--
+
+  # S390X 16vCPU / 64GiB RAM / 1TB disk
+  host.s390x-static-1.address: "127.0.0.1"
+  host.s390x-static-1.platform: "linux/s390x"
+  host.s390x-static-1.user: "root"
+  host.s390x-static-1.secret: "ibm-s390x-test-secret"
+  host.s390x-static-1.concurrency: "4"
+
+  host.s390x-static-2.address: "127.0.0.1"
+  host.s390x-static-2.platform: "linux/s390x"
+  host.s390x-static-2.user: "root"
+  host.s390x-static-2.secret: "ibm-s390x-test-secret"
+  host.s390x-static-2.concurrency: "4"
+
+  host.s390x-static-3.address: "127.0.0.1"
+  host.s390x-static-3.platform: "linux/s390x"
+  host.s390x-static-3.user: "root"
+  host.s390x-static-3.secret: "ibm-s390x-test-secret"
+  host.s390x-static-3.concurrency: "4"
+
+  host.s390x-static-4.address: "127.0.0.1"
+  host.s390x-static-4.platform: "linux/s390x"
+  host.s390x-static-4.user: "root"
+  host.s390x-static-4.secret: "ibm-s390x-test-secret"
+  host.s390x-static-4.concurrency: "4"
+
+  host.s390x-static-5.address: "127.0.0.1"
+  host.s390x-static-5.platform: "linux/s390x"
+  host.s390x-static-5.user: "root"
+  host.s390x-static-5.secret: "ibm-s390x-test-secret"
+  host.s390x-static-5.concurrency: "4"
+
+  host.s390x-static-6.address: "127.0.0.1"
+  host.s390x-static-6.platform: "linux/s390x"
+  host.s390x-static-6.user: "root"
+  host.s390x-static-6.secret: "ibm-s390x-test-secret"
+  host.s390x-static-6.concurrency: "4"
+
+  host.s390x-static-7.address: "127.0.0.1"
+  host.s390x-static-7.platform: "linux/s390x"
+  host.s390x-static-7.user: "root"
+  host.s390x-static-7.secret: "ibm-s390x-test-secret"
+  host.s390x-static-7.concurrency: "4"
+
+  host.s390x-static-8.address: "127.0.0.1"
+  host.s390x-static-8.platform: "linux/s390x"
+  host.s390x-static-8.user: "root"
+  host.s390x-static-8.secret: "ibm-s390x-test-secret"
+  host.s390x-static-8.concurrency: "4"
+
+  host.s390x-static-9.address: "127.0.0.1"
+  host.s390x-static-9.platform: "linux/s390x"
+  host.s390x-static-9.user: "root"
+  host.s390x-static-9.secret: "ibm-s390x-test-secret"
+  host.s390x-static-9.concurrency: "4"
+
+  host.s390x-static-10.address: "127.0.0.1"
+  host.s390x-static-10.platform: "linux/s390x"
+  host.s390x-static-10.user: "root"
+  host.s390x-static-10.secret: "ibm-s390x-test-secret"
+  host.s390x-static-10.concurrency: "4"
+
+  # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
+  host.ppc64le-pi-static-x0.address: "127.0.0.1"
+  host.ppc64le-pi-static-x0.platform: "linux/ppc64le"
+  host.ppc64le-pi-static-x0.user: "root"
+  host.ppc64le-pi-static-x0.secret: "ibm-ppc64le-test-secret"
+  host.ppc64le-pi-static-x0.concurrency: "8"
+
+  host.ppc64le-pi-static-x1.address: "127.0.0.1"
+  host.ppc64le-pi-static-x1.platform: "linux/ppc64le"
+  host.ppc64le-pi-static-x1.user: "root"
+  host.ppc64le-pi-static-x1.secret: "ibm-ppc64le-test-secret"
+  host.ppc64le-pi-static-x1.concurrency: "8"
+
+  host.ppc64le-pi-static-x2.address: "127.0.0.1"
+  host.ppc64le-pi-static-x2.platform: "linux/ppc64le"
+  host.ppc64le-pi-static-x2.user: "root"
+  host.ppc64le-pi-static-x2.secret: "ibm-ppc64le-test-secret"
+  host.ppc64le-pi-static-x2.concurrency: "8"
+
+  host.ppc64le-pi-static-x3.address: "127.0.0.1"
+  host.ppc64le-pi-static-x3.platform: "linux/ppc64le"
+  host.ppc64le-pi-static-x3.user: "root"
+  host.ppc64le-pi-static-x3.secret: "ibm-ppc64le-test-secret"
+  host.ppc64le-pi-static-x3.concurrency: "8"
+
+  host.ppc64le-pi-static-x4.address: "127.0.0.1"
+  host.ppc64le-pi-static-x4.platform: "linux/ppc64le"
+  host.ppc64le-pi-static-x4.user: "root"
+  host.ppc64le-pi-static-x4.secret: "ibm-ppc64le-test-secret"
+  host.ppc64le-pi-static-x4.concurrency: "8"
+
+  # AWS GPU Nodes
+  dynamic.linux-g6xlarge-amd64.type: "aws"
+  dynamic.linux-g6xlarge-amd64.region: "us-east-1"
+  dynamic.linux-g6xlarge-amd64.ami: "ami-0xxxxxxxxxxxx9"
+  dynamic.linux-g6xlarge-amd64.instance-type: "g6.xlarge"
+  dynamic.linux-g6xlarge-amd64.key-name: "konflux-test-string"
+  dynamic.linux-g6xlarge-amd64.aws-secret: "aws-account"
+  dynamic.linux-g6xlarge-amd64.ssh-secret: "aws-ssh-key"
+  dynamic.linux-g6xlarge-amd64.security-group-id: "sg-0xxxxxxxxxxxxe"
+  dynamic.linux-g6xlarge-amd64.subnet-id: "subnet-0xxxxxxxxxxxxe"
+  dynamic.linux-g6xlarge-amd64.max-instances: "250"
+  dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-g6xlarge-amd64.instance-tag: "prod-amd64-g6xlarge"
+  dynamic.linux-g6xlarge-amd64.user-data: |-
+    Content-Type: multipart/mixed; boundary="//"
+    MIME-Version: 1.0
+    
+    --//
+    I have a friend, he fried his brain backpacking through India
+    Thinks he's a hedgehog
+    Moshe - you are not a hedgehog
+    Moshe - you are not a hedgehog
+    Not a hedgehog, not a hedgehog, not a hedgehog
+    --//--


### PR DESCRIPTION
Committing the initial work  for the task:
1. Introduces typed structs for the various types of hosts available in host-config.yaml along with a full validation function for the configurations in it.
2. Refactor taskrun->readConfiguration to use this new, safe model instead of a raw map.
3. Tests for all new functions and functionalities.

Assisted-by: Claude Code