### PR TITLE
KONFLUX-9232: OTP ssh validation

### DIFF
--- a/cmd/otp/otp_servehttp_test.go
+++ b/cmd/otp/otp_servehttp_test.go
@@ -142,7 +142,7 @@ var _ = Describe("ServeHTTP handlers", Serial, func() {
 				testStorekey.ServeHTTP(rr, req)
 
 				Expect(rr.Code).To(Equal(http.StatusInternalServerError))
-				Expect(logCapture.Contains("failed to read request body")).To(BeTrue(), "Log should indicate empty body")
+				Expect(logCapture.Contains("request body is empty")).To(BeTrue(), "Log should indicate empty body")
 			})
 
 			It("returns 500 for non-ssh string", func() {


### PR DESCRIPTION
## What
- Added SSH key validation to the /store-key endpoint (empty body, malformed keys, prefix mismatches)
- Added helper function startsWithKeyType() to validate SSH key type prefixes
- Improved error messages and code comments
- Added test coverage for invalid SSH key scenarios (empty strings, malformed keys, bad prefixes, truncated keys)

## Why
Invalidating ssh keys in our current state can cause number of problems, the changes can help with:
- Potential security issues from accepting malformed data
- Debug the OTP issues with more concise error massages in the logs
- Increasing test coverage