### PR TITLE
update rpms-signature-scan to fix releases

### DIFF
--- a/.tekton/multi-platform-controller-otp-service-pull-request.yaml
+++ b/.tekton/multi-platform-controller-otp-service-pull-request.yaml
@@ -558,7 +558,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1bd72f07e607b41fc2f1ef1fd0fb840699e49f113128b5dc0b387b5c2757cb38
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/multi-platform-controller-otp-service-push.yaml
+++ b/.tekton/multi-platform-controller-otp-service-push.yaml
@@ -567,7 +567,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1bd72f07e607b41fc2f1ef1fd0fb840699e49f113128b5dc0b387b5c2757cb38
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/multi-platform-controller-pull-request.yaml
+++ b/.tekton/multi-platform-controller-pull-request.yaml
@@ -547,7 +547,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1bd72f07e607b41fc2f1ef1fd0fb840699e49f113128b5dc0b387b5c2757cb38
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/multi-platform-controller-push.yaml
+++ b/.tekton/multi-platform-controller-push.yaml
@@ -567,7 +567,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:0b10508c82ccb0f5a06a66ce7af56e9bfd40651ddefdf0f499988e897771ee28
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1bd72f07e607b41fc2f1ef1fd0fb840699e49f113128b5dc0b387b5c2757cb38
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Our releases are failing because the `rpms-signature-scan` task is out of date.

This change moves from `konflux-vanguard/task-rpms-signature-scan` to the latest revision of `konflux-ci/task-rpms-signature-scan`.

Signed-off-by: Francesco Ilario <filario@redhat.com>
