### PR TITLE
Add codecov.yml with carryforward for e2e-tests flag

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+flags:
+  unit-tests:
+    carryforward: false
+  e2e-tests:
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,17 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
 flags:
   unit-tests:
     carryforward: false
   e2e-tests:
     carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default


### PR DESCRIPTION
## Summary

- Add `codecov.yml` with standard settings 
- Enable `carryforward: true` for the `e2e-tests` Codecov flag so that when e2e tests are skipped on a PR (e.g. from an untrusted fork), Codecov reuses the last known e2e coverage instead of treating it as zero.
- This eliminates false "indirect changes" regressions on untouched files caused by the missing e2e coverage flag.

## Context

When a PR only uploads the `unit-tests` flag (because e2e tests were skipped), Codecov compares base coverage (unit + e2e merged) against head coverage (unit only). Files covered exclusively by e2e tests appear to regress even though the code was never touched. Carryforward solves this by persisting the last uploaded e2e coverage across commits that don't re-upload it.

## Test plan

- [x] Verify codecov.yml syntax is valid
- [ ] Merge and confirm that future PRs with skipped e2e tests no longer show phantom regressions in the "indirect changes" tab

## Jira
https://redhat.atlassian.net/browse/KONFLUX-13427

Made with [Cursor](https://cursor.com)