### PR TITLE
[KFLUXINFRA-2783] Fix orphaned EC2 instances caused by premature Clou…

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -195,6 +195,11 @@ func (ec AWSEc2DynamicConfig) GetInstanceAddress(kubeClient client.Client, ctx c
 // TerminateInstance tries to delete the instanceID EC2 instance.
 func (ec AWSEc2DynamicConfig) TerminateInstance(kubeClient client.Client, ctx context.Context, instanceID cloud.InstanceIdentifier) error {
 	log := logr.FromContextOrDiscard(ctx)
+	if instanceID == "" {
+		err := errors.New("cannot terminate instance: empty instance ID")
+		log.Error(err, "cannot terminate instance: empty instance ID")
+		return err
+	}
 	log.Info("Attempting to terminate AWS EC2 instance", "instanceID", instanceID)
 
 	// Use AWS credentials and configuration to create an EC2 client

--- a/pkg/reconciler/taskrun/dynamic.go
+++ b/pkg/reconciler/taskrun/dynamic.go
@@ -65,6 +65,8 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 				terr := r.TerminateInstance(taskRun.client, ctx, cloud.InstanceIdentifier(tr.Annotations[CloudInstanceId]))
 				if terr != nil {
 					log.Error(err, "Failed to terminate instance")
+				} else {
+					delete(tr.Annotations, CloudInstanceId)
 				}
 				unassignErr := r.removeInstanceFromTask(taskRun, ctx, tr)
 				if unassignErr != nil {
@@ -90,6 +92,8 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 				message := fmt.Sprintf("failed to terminate %s instance for %s", r.instanceTag, tr.Name)
 				r.eventRecorder.Event(tr, "Normal", "TerminateFailed", message)
 				log.Error(terr, message)
+			} else {
+				delete(tr.Annotations, CloudInstanceId)
 			}
 			unassignErr := r.removeInstanceFromTask(taskRun, ctx, tr)
 			if unassignErr != nil {
@@ -113,6 +117,8 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 				if terr != nil {
 					message := fmt.Sprintf("failed to terminate %s instance for %s", r.instanceTag, tr.Name)
 					log.Error(terr, message)
+				} else {
+					delete(tr.Annotations, CloudInstanceId)
 				}
 				unassignErr := r.removeInstanceFromTask(taskRun, ctx, tr)
 				if unassignErr != nil {
@@ -140,6 +146,8 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 					message := fmt.Sprintf("failed to terminate %s instance for %s", r.instanceTag, tr.Name)
 					r.eventRecorder.Event(tr, "Normal", "TerminateFailed", message)
 					log.Error(terr, message)
+				} else {
+					delete(tr.Annotations, CloudInstanceId)
 				}
 				unassignErr := r.removeInstanceFromTask(taskRun, ctx, tr)
 				if unassignErr != nil {
@@ -236,7 +244,6 @@ func (r DynamicResolver) Allocate(taskRun *ReconcileTaskRun, ctx context.Context
 // Tries to remove the instance information from the task and returns a non-nil error if it was unable to.
 func (dr DynamicResolver) removeInstanceFromTask(reconcileTaskRun *ReconcileTaskRun, ctx context.Context, taskRun *v1.TaskRun) error {
 	delete(taskRun.Labels, constant.AssignedHost)
-	delete(taskRun.Annotations, CloudInstanceId)
 	delete(taskRun.Annotations, CloudDynamicPlatform)
 	return UpdateTaskRunWithRetry(ctx, reconcileTaskRun.client, reconcileTaskRun.apiReader, taskRun)
 }


### PR DESCRIPTION
**Summary**                                                                                                                                                                                                            
                  
Fixes a bug where EC2 instances become orphaned because the CloudInstanceId annotation (build.appstudio.redhat.com/cloud-instance-id) is removed before the instance is actually terminated.                       
                  
**Root Cause**                                                                                                                                                                                                         
                  
`removeInstanceFromTask()` in `dynamic.go` deletes the `CloudInstanceId` annotation during error/retry paths in `Allocate()`. When the next reconciliation loop attempts cleanup, it reads an empty instance ID and calls  `TerminateInstances` with an empty string. AWS rejects the call with 400 `InvalidInstanceID.Malformed`, and the EC2 instance is never terminated.

                                                                                                             
This was confirmed via Splunk logs on `stone-prd-rh01`:                                                                                                                                                              
```
taskrun/dynamic.go:38 Failed to terminate dynamic instance
EC2 TerminateInstances StatusCode: 400                                                                                                                                                                             
InvalidInstanceID.Malformed:                                                                                                                                                                                       
The instance ID '' is malformed       
```                                                                                                                                                                             
                                                                                                                                                        
**Changes**                                                                                                                                                                                                            
                                                                                                                                                                                                                     

- pkg/reconciler/taskrun/dynamic.go: Stop deleting CloudInstanceId in removeInstanceFromTask(). The annotation is only needed for cleanup and is already correctly removed in Deallocate() after successful termination.                                                                                                                                                                                                       
- pkg/aws/ec2.go: Add an empty instance ID guard in TerminateInstance() to fail fast with a clear error instead of sending a malformed request to AWS.                                                             

                                                                                                                                                                                                                     
**Testing**
                                                                                                                                                                                                                     

- Verified that `Deallocate()` still removes the annotation after successful termination.                                                                                                               
- The empty-ID guard ensures any future regression produces a clear log message rather than a silent AWS 400.

                                                                                                                                                                                                                     
**Resolves**: [KFLUXINFRA-2783 ](https://redhat.atlassian.net/browse/KFLUXINFRA-2783)                                