### PR TITLE
feat: Add deptriage workflows for automated dependency PR triage

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,27 @@
+name: Auto-merge approved dependency PRs
+
+on:
+  check_suite:
+    types: [completed]
+
+jobs:
+  auto-merge:
+    name: Merge if all checks pass
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_ID }}
+          private-key: ${{ secrets.KONFLUX_INFRA_AUTO_MERGER_APP_PRIVATE_KEY }}
+      - uses: konflux-ci/deptriage@main
+        with:
+          command: merge
+          head-sha: ${{ github.event.check_suite.head_sha }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/dep-triage.yaml
+++ b/.github/workflows/dep-triage.yaml
@@ -1,0 +1,33 @@
+name: Dependency Impact Analysis
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: dep-triage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Triage dependency PR
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'red-hat-konflux[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: konflux-ci/deptriage@main
+        with:
+          command: both
+          pr-number: ${{ github.event.pull_request.number }}
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          llm-provider: gemini
+          auto-approve: 'true'
+          auto-merge: 'true'


### PR DESCRIPTION
Adds two GitHub Actions workflows:
- dep-triage.yaml: classifies, analyzes, and auto-approves dependency PRs
- auto-merge.yaml: merges approved dependency PRs when all checks pass