### PR TITLE
KFLUXINFRA-3956 Make otelcol-contrib installation non-fatal when GitHub is unavailable

### DIFF
--- a/deploy/operator/provision-shared-host.sh
+++ b/deploy/operator/provision-shared-host.sh
@@ -40,27 +40,31 @@ if command -v otelcol-contrib >/dev/null 2>&1; then
   sudo systemctl restart otelcol-contrib
 else
   if [[ -f /etc/otelcol-contrib/config_mpc.yaml ]]; then
-    PKG="otelcol-contrib_0.140.0_${PLATFORM}.rpm"
-    URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.140.0/\$PKG"
+    PKG="otelcol-contrib_0.154.0_${PLATFORM}.rpm"
+    URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.154.0/\$PKG"
     echo "Downloading: \$URL"
-    curl -LO "\$URL" || exit 1
-    sudo rpm -ivh "\$PKG" || exit 1
-    # Ensure config dir exists
-    sudo install -d /etc/otelcol-contrib
+    if ! curl -LO --fail "\$URL"; then
+      echo "Warning: failed to download otelcol-contrib (GitHub may be unavailable). Skipping installation."
+    elif ! sudo rpm -ivh "\$PKG"; then
+      echo "Warning: failed to install otelcol-contrib RPM. Skipping installation."
+    else
+      # Ensure config dir exists
+      sudo install -d /etc/otelcol-contrib
 
-    # Patch config file name (overwrite)
-    echo 'OTELCOL_OPTIONS="--config=/etc/otelcol-contrib/config_mpc.yaml"' \
-      | sudo tee /etc/otelcol-contrib/otelcol-contrib.conf >/dev/null
+      # Patch config file name (overwrite)
+      echo 'OTELCOL_OPTIONS="--config=/etc/otelcol-contrib/config_mpc.yaml"' \
+        | sudo tee /etc/otelcol-contrib/otelcol-contrib.conf >/dev/null
 
-    # Add user to groups BEFORE restart
-    sudo usermod -aG adm,systemd-journal otelcol-contrib
+      # Add user to groups BEFORE restart
+      sudo usermod -aG adm,systemd-journal otelcol-contrib
 
-    # Set ACLs to read the audit log
-    sudo setfacl -m u:otelcol-contrib:r /var/log/audit/audit.log
-    sudo setfacl -m u:otelcol-contrib:rx /var/log/audit
+      # Set ACLs to read the audit log
+      sudo setfacl -m u:otelcol-contrib:r /var/log/audit/audit.log
+      sudo setfacl -m u:otelcol-contrib:rx /var/log/audit
 
-    sudo systemctl daemon-reload
-    sudo systemctl restart otelcol-contrib
+      sudo systemctl daemon-reload
+      sudo systemctl restart otelcol-contrib
+    fi
   else
     echo "Opentelemetry config not found, skipping installation."
   fi

--- a/deploy/operator/provision-shared-host.sh
+++ b/deploy/operator/provision-shared-host.sh
@@ -40,8 +40,8 @@ if command -v otelcol-contrib >/dev/null 2>&1; then
   sudo systemctl restart otelcol-contrib
 else
   if [[ -f /etc/otelcol-contrib/config_mpc.yaml ]]; then
-    PKG="otelcol-contrib_0.154.0_${PLATFORM}.rpm"
-    URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.154.0/\$PKG"
+    PKG="otelcol-contrib_0.150.0_${PLATFORM}.rpm"
+    URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.150.0/\$PKG"
     echo "Downloading: \$URL"
     if ! curl -LO --fail "\$URL"; then
       echo "Warning: failed to download otelcol-contrib (GitHub may be unavailable). Skipping installation."

--- a/deploy/operator/provision-shared-host.sh
+++ b/deploy/operator/provision-shared-host.sh
@@ -40,8 +40,8 @@ if command -v otelcol-contrib >/dev/null 2>&1; then
   sudo systemctl restart otelcol-contrib
 else
   if [[ -f /etc/otelcol-contrib/config_mpc.yaml ]]; then
-    PKG="otelcol-contrib_0.150.0_${PLATFORM}.rpm"
-    URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.150.0/\$PKG"
+    PKG="otelcol-contrib_0.151.0_${PLATFORM}.rpm"
+    URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.151.0/\$PKG"
     echo "Downloading: \$URL"
     if ! curl -LO --fail --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "\$URL"; then
       echo "Warning: failed to download otelcol-contrib (GitHub may be unavailable). Skipping installation."

--- a/deploy/operator/provision-shared-host.sh
+++ b/deploy/operator/provision-shared-host.sh
@@ -43,7 +43,7 @@ else
     PKG="otelcol-contrib_0.150.0_${PLATFORM}.rpm"
     URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.150.0/\$PKG"
     echo "Downloading: \$URL"
-    if ! curl -LO --fail "\$URL"; then
+    if ! curl -LO --fail --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "\$URL"; then
       echo "Warning: failed to download otelcol-contrib (GitHub may be unavailable). Skipping installation."
     elif ! sudo rpm -ivh "\$PKG"; then
       echo "Warning: failed to install otelcol-contrib RPM. Skipping installation."

--- a/deploy/overlays/dev-template/otelcollector.yaml
+++ b/deploy/overlays/dev-template/otelcollector.yaml
@@ -74,7 +74,7 @@ stringData:
         log_statements:
           - context: resource
             statements:
-              - set(attributes["s3.prefix"], Concat(["GITHUB_RUN_ID", attributes["host.id"]], "/"))
+              - set(attributes["s3.prefix"], Concat(["${env:GITHUB_RUN_ID}", attributes["host.id"]], "/"))
     receivers:
       filelog/e2e_audit:
         include:

--- a/deploy/overlays/dev-template/otelcollector.yaml
+++ b/deploy/overlays/dev-template/otelcollector.yaml
@@ -56,9 +56,6 @@ stringData:
           - ec2
         override: true
       resourcedetection/system:
-        attributes:
-          - host.name
-          - os.type
         detectors:
           - system
         override: true

--- a/deploy/overlays/dev-template/otelcollector.yaml
+++ b/deploy/overlays/dev-template/otelcollector.yaml
@@ -74,7 +74,7 @@ stringData:
         log_statements:
           - context: resource
             statements:
-              - set(attributes["s3.prefix"], Concat(["${env:GITHUB_RUN_ID}", attributes["host.id"]], "/"))
+              - set(attributes["s3.prefix"], Concat(["GITHUB_RUN_ID", attributes["host.id"]], "/"))
     receivers:
       filelog/e2e_audit:
         include:


### PR DESCRIPTION
## Summary

- Added `--fail` to `curl` so that HTTP error responses (e.g. 504 Gateway Timeout HTML bodies) are detected as failures rather than silently saved as a corrupt file.
- Wrapped the download and RPM install in a non-fatal `if/elif/else` block: when GitHub is unreachable, a warning is printed and the otelcol step is skipped entirely instead of aborting provisioning.
- Bumped `otelcol-contrib` version from `0.140.0` to `0.151.0` 

The host still provisions successfully (users, SSH keys, etc.) when GitHub is down. On the next provisioning run for that host, otelcol will be retried automatically because the binary won't be present.

## Test plan

- [ ] Verify provisioning succeeds end-to-end when GitHub is reachable (happy path, otelcol installed as before).
- [ ] Simulate GitHub unavailability (e.g. bad URL or network block) and confirm the script prints the warning and continues past the otelcol block without exiting.

## Related issues

Fixes the 504-caused provisioning failure reported in shared host provisioning logs.

Made with [Cursor](https://cursor.com)