### PR TITLE
KONFLUX-14156 add curl retry and timeouts to OTP server calls

### DIFF
--- a/deploy/operator/kustomization.yaml
+++ b/deploy/operator/kustomization.yaml
@@ -19,14 +19,17 @@ configMapGenerator:
     namespace: multi-platform-controller
     files:
       - provision-shared-host.sh
+      - otp-utils.sh
   - name: provision-macos-host-script
     namespace: multi-platform-controller
     files:
       - provision-host-macos.sh
+      - otp-utils.sh
   - name: provision-windows-host-script
     namespace: multi-platform-controller
     files:
       - provision-host-windows.sh
+      - otp-utils.sh
   - name: clean-shared-host-script
     namespace: multi-platform-controller
     files:

--- a/deploy/operator/otp-utils.sh
+++ b/deploy/operator/otp-utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Sourced by provisioning scripts — inherits set -eu, pipefail, and ERR trap from parent.
+
+# curl_otp_store_key runs curl with retry logic for transient errors.
+# Usage: result=$(curl_otp_store_key --fail --connect-timeout 5 ... URL)
+curl_otp_store_key() {
+  local otp_fail_prefix='{message: "Failed to store SSH key in OTP server'
+  local otp_fail_suffix='. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.", level: "ERROR"}'
+  local otp_raw=""
+  for i in {3..1}; do
+    otp_raw=$(curl "$@") && break
+    rc=$?
+    case "$rc" in
+      6|7|22|28|35|56) ;; # transient: DNS, conn refused, HTTP 5xx, timeout, TLS, recv failure
+      *) echo "${otp_fail_prefix} (curl exit ${rc})${otp_fail_suffix}" >&2
+         exit 1 ;;
+    esac
+    ATTEMPTS_REMAINING=$((i - 1))
+    if [ "$ATTEMPTS_REMAINING" -gt 0 ]; then
+      echo "{message: \"OTP server /store-key call failed (curl exit $rc), retrying $ATTEMPTS_REMAINING more times...\", level: \"WARNING\"}" >&2
+      sleep 1
+    else
+      echo "${otp_fail_prefix} after 3 attempts${otp_fail_suffix}" >&2
+      exit 1
+    fi
+  done
+  if [ -z "$otp_raw" ]; then
+    echo "{message: \"OTP server returned an empty token. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
+    exit 1
+  fi
+  printf '%s' "$otp_raw"
+}

--- a/deploy/operator/provision-host-macos.sh
+++ b/deploy/operator/provision-host-macos.sh
@@ -3,6 +3,8 @@ set -o verbose
 set -eu
 set -o pipefail
 
+. /scripts/otp-utils.sh
+
 # --- Error Handling Function ---
 handle_error() {
     local EXIT_CODE=$?
@@ -46,15 +48,8 @@ DIR=$(echo "/Users/${USERNAME}" | base64 -w 0)
 if [ -e "/tls/tls.crt" ]; then
     echo "{message: \"Creating secret file using TLS certificate...\", level: \"INFO\"}"
     KEY=$(cat id_rsa)
-    if ! otp_raw=$(curl --fail --cacert /tls/tls.crt -XPOST -d "$KEY" https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/store-key); then
-      echo "{message: \"Failed to store SSH key in OTP server. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
-      exit 1
-    fi
+    otp_raw=$(curl_otp_store_key --fail --connect-timeout 5 --max-time 30 --cacert /tls/tls.crt -XPOST -d "$KEY" https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/store-key)
     OTP=$(printf '%s' "$otp_raw" | base64 -w 0)
-    if [ -z "$OTP" ]; then
-      echo "{message: \"OTP server returned an empty token. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
-      exit 1
-    fi
     OTP_SERVER="$(echo https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/otp | base64 -w 0)"
     echo "$OTP" | base64 -d
 

--- a/deploy/operator/provision-host-windows.sh
+++ b/deploy/operator/provision-host-windows.sh
@@ -3,6 +3,8 @@ set -o verbose
 set -eu
 set -o pipefail
 
+. /scripts/otp-utils.sh
+
 # --- Error Handling Function ---
 handle_error() {
     local EXIT_CODE=$?
@@ -47,15 +49,8 @@ DIR=$(echo 'C:\\Users\\'"${USERNAME}" | base64 -w 0)
 if [ -e "/tls/tls.crt" ]; then
     echo "{message: \"Creating secret file using TLS certificate...\", level: \"INFO\"}"
     KEY=$(cat id_rsa)
-    if ! otp_raw=$(curl --fail --cacert /tls/tls.crt -XPOST -d "$KEY" https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/store-key); then
-      echo "{message: \"Failed to store SSH key in OTP server. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
-      exit 1
-    fi
+    otp_raw=$(curl_otp_store_key --fail --connect-timeout 5 --max-time 30 --cacert /tls/tls.crt -XPOST -d "$KEY" https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/store-key)
     OTP=$(printf '%s' "$otp_raw" | base64 -w 0)
-    if [ -z "$OTP" ]; then
-      echo "{message: \"OTP server returned an empty token. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
-      exit 1
-    fi
     OTP_SERVER="$(echo https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/otp | base64 -w 0)"
     echo "$OTP" | base64 -d
 

--- a/deploy/operator/provision-shared-host.sh
+++ b/deploy/operator/provision-shared-host.sh
@@ -3,6 +3,8 @@ set -o verbose
 set -eu
 set -o pipefail
 
+. /scripts/otp-utils.sh
+
 # --- Error Handling Function ---
 handle_error() {
     local EXIT_CODE=$?
@@ -209,15 +211,8 @@ DIR=$(echo /home/"$USERNAME" | base64 -w 0)
 if [ -e "/tls/tls.crt" ]; then
   echo "{message: \"Creating secret file using TLS certificate...\", level: \"INFO\"}"
   KEY=$(cat id_rsa)
-  if ! otp_raw=$(curl --fail --cacert /tls/tls.crt -XPOST -d "$KEY" https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/store-key); then
-    echo "{message: \"Failed to store SSH key in OTP server. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
-    exit 1
-  fi
+  otp_raw=$(curl_otp_store_key --fail --connect-timeout 5 --max-time 30 --cacert /tls/tls.crt -XPOST -d "$KEY" https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/store-key)
   OTP=$(printf '%s' "$otp_raw" | base64 -w 0)
-  if [ -z "$OTP" ]; then
-    echo "{message: \"OTP server returned an empty token. Please, retry build in a few minutes, and if problem persists, please report it as an MPC bug.\", level: \"ERROR\"}" >&2
-    exit 1
-  fi
   OTP_SERVER="$(echo https://multi-platform-otp-server.multi-platform-controller.svc.cluster.local/otp | base64 -w 0)"
   echo "$OTP" | base64 -d
 


### PR DESCRIPTION
## Summary

Add a shell retry loop to OTP `/store-key` curl calls to handle transient failures under high concurrency (1% failure rate at 200 concurrent RPM builds on stone-stg-rh01).

Resolves: [KONFLUX-14156](https://redhat.atlassian.net/browse/KONFLUX-14156)

Based on #946 — refined to use a shell retry loop instead of curl's `--retry-all-errors` for precise control over which errors trigger a retry.

## Changes

- New `deploy/operator/otp-utils.sh` — shared `curl_otp_store_key()` function with retry loop and empty-token validation
- `deploy/operator/kustomization.yaml` — add `otp-utils.sh` to all three provisioning ConfigMaps
- `deploy/operator/provision-shared-host.sh` — source `otp-utils.sh`, replace inline curl + empty-token check with `curl_otp_store_key()`
- `deploy/operator/provision-host-macos.sh` — same
- `deploy/operator/provision-host-windows.sh` — same

The retry loop retries only on transient curl exit codes:
- **6**: DNS resolution failure — the reported issue
- **7**: connection refused — pod not ready
- **22**: HTTP error via `--fail` (e.g. 503 during startup)
- **28**: timeout — with `--connect-timeout 5`, this is a connect-phase timeout
- **35**: TLS handshake failure — cert not available after pod restart
- **56**: receive failure — connection dropped mid-transfer

All other errors fail immediately without retry.

## Testing

- [x] `make fmt` passes
- [x] `make lint` passes
- [x] `make test` passes (46/46 specs, 78.4% composite coverage)
- [x] `shellcheck` passes (zero warnings on `otp-utils.sh`)
- [x] `kustomize build` renders `otp-utils.sh` in all three provisioning ConfigMaps
- [x] Local function test confirms retry on DNS failure and stderr-only logging
- [ ] CI checks pass (go-ci, mpc-test, test-e2e)

## Coverage

Shell-only changes — no Go code modified, no coverage impact.

## Notes

- curl's `--retry-connrefused` only covers exit code 7, not DNS failures (exit code 6). `--retry-all-errors` retries more broadly than needed. A shell loop gives precise control.
- `otp-utils.sh` is a sourced library — it inherits `set -eu`, `pipefail`, and the ERR trap from the parent script.

Closes #945

[KONFLUX-14156]: https://redhat.atlassian.net/browse/KONFLUX-14156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ