### PR TITLE
Replace deprecated buildah-task image with task-runner in e2e tests

### DIFF
--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -183,7 +183,7 @@ var _ = Describe("TaskRun execution", func() {
 					Steps: []tekv1.Step{
 						{
 							Name:   "verify-platform",
-							Image:  "quay.io/konflux-ci/buildah-task:latest",
+							Image:  "quay.io/konflux-ci/task-runner:latest",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? Link the Jira ticket. -->
Replace deprecated buildah-task image with task-runner in e2e tests

## Changes
<!-- Bullet list of what changed. Be specific about files/packages. -->
Replace deprecated buildah-task image with task-runner in e2e tests

## Testing
<!-- How was this tested? What passed? -->
- [ ] e2e tests passing

## Coverage
<!-- Patch coverage target: 100%. Never drop repo below 76%. -->
<!-- If >8 files changed, explain the split strategy or link paired PRs. -->

## Notes
<!-- Anything reviewers should know: trade-offs, follow-ups, risks. -->
