### PR TITLE
Replace deprecated buildah-task image with task-runner in e2e tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,7 +83,7 @@
         "test/e2e/taskrun/taskrun_test.go"
       ],
       "matchStrings": [
-        "(?s)// renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?).*?Image:\\s+\"[^\"]+:(?<currentValue>[^\"]+)\""
+        "(?s)// renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>\\S+))? packageName=(?<packageName>\\S+).*?Image:\\s+\"[^\"]+:(?<currentValue>[^\"]+)\""
       ]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,6 +75,16 @@
       "matchStrings": [
         "#\\s+?renovate:\\s+?datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s+?.+?_VERSION\\s+?\\?=\\s+?(?<currentValue>.+?)\\s"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update container images in e2e tests",
+      "managerFilePatterns": [
+        "test/e2e/taskrun/taskrun_test.go"
+      ],
+      "matchStrings": [
+        "(?s)// renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?).*?Image:\\s+\"[^\"]+:(?<currentValue>[^\"]+)\""
+      ]
     }
   ]
 }

--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -182,9 +182,9 @@ var _ = Describe("TaskRun execution", func() {
 					},
 					Steps: []tekv1.Step{
 						{
-							Name:  "verify-platform",
+							Name: "verify-platform",
 							// renovate: datasource=docker depName=task-runner packageName=quay.io/konflux-ci/task-runner
-							Image: "quay.io/konflux-ci/task-runner:2.1.0",
+							Image:  "quay.io/konflux-ci/task-runner:2.1.0",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -182,7 +182,8 @@ var _ = Describe("TaskRun execution", func() {
 					},
 					Steps: []tekv1.Step{
 						{
-							Name:   "verify-platform",
+							Name: "verify-platform",
+							// renovate: datasource=docker depName=task-runner packageName=quay.io/konflux-ci/task-runner
 							Image:  "quay.io/konflux-ci/task-runner:2.1.0",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{

--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -183,7 +183,7 @@ var _ = Describe("TaskRun execution", func() {
 					Steps: []tekv1.Step{
 						{
 							Name:   "verify-platform",
-							Image:  "quay.io/konflux-ci/task-runner:latest@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9",
+							Image:  "quay.io/konflux-ci/task-runner:2.1.0",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -182,9 +182,9 @@ var _ = Describe("TaskRun execution", func() {
 					},
 					Steps: []tekv1.Step{
 						{
-							Name: "verify-platform",
+							Name:  "verify-platform",
 							// renovate: datasource=docker depName=task-runner packageName=quay.io/konflux-ci/task-runner
-							Image:  "quay.io/konflux-ci/task-runner:2.1.0",
+							Image: "quay.io/konflux-ci/task-runner:2.1.0",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -183,7 +183,7 @@ var _ = Describe("TaskRun execution", func() {
 					Steps: []tekv1.Step{
 						{
 							Name:   "verify-platform",
-							Image:  "quay.io/konflux-ci/buildah-task:latest",
+							Image:  "quay.io/konflux-ci/task-runner:latest",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/test/e2e/taskrun/taskrun_test.go
+++ b/test/e2e/taskrun/taskrun_test.go
@@ -183,7 +183,7 @@ var _ = Describe("TaskRun execution", func() {
 					Steps: []tekv1.Step{
 						{
 							Name:   "verify-platform",
-							Image:  "quay.io/konflux-ci/task-runner:latest",
+							Image:  "quay.io/konflux-ci/task-runner:latest@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9",
 							Script: script,
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? Link the Jira ticket. -->
Replace deprecated buildah-task image with task-runner in e2e tests

## Changes
<!-- Bullet list of what changed. Be specific about files/packages. -->
Replace deprecated buildah-task image with task-runner in e2e tests

## Testing
<!-- How was this tested? What passed? -->
- [x] e2e tests passing

## Coverage
<!-- Patch coverage target: 100%. Never drop repo below 76%. -->
<!-- If >8 files changed, explain the split strategy or link paired PRs. -->

## Notes
<!-- Anything reviewers should know: trade-offs, follow-ups, risks. -->
