### PR TITLE
KFLUXINFRA-4235 Fix Windows AMI: use Server 2025 Core Base

### DIFF
--- a/deploy/overlays/dev-template/host-config.yaml
+++ b/deploy/overlays/dev-template/host-config.yaml
@@ -39,7 +39,7 @@ data:
 
   dynamic.windows-c4xlarge-amd64.type: aws
   dynamic.windows-c4xlarge-amd64.region: us-east-1
-  dynamic.windows-c4xlarge-amd64.ami: ami-0ab5e8edee718de14
+  dynamic.windows-c4xlarge-amd64.ami: ami-07adb88c7ad360947
   dynamic.windows-c4xlarge-amd64.instance-type: c5.4xlarge
   dynamic.windows-c4xlarge-amd64.key-name: AWS_SSH_KEY_NAME
   dynamic.windows-c4xlarge-amd64.aws-secret: awsiam
@@ -47,6 +47,7 @@ data:
   dynamic.windows-c4xlarge-amd64.security-group-id: sg-0dac40dc35d0bf1c4
   dynamic.windows-c4xlarge-amd64.max-instances: "4"
   dynamic.windows-c4xlarge-amd64.subnet-id: subnet-02b7d6698c619e5a2
+  dynamic.windows-c4xlarge-amd64.allocation-timeout: "1200"
   dynamic.windows-c4xlarge-amd64.strict-public-address: "true"
   dynamic.windows-c4xlarge-amd64.user-data: |-
       <powershell>
@@ -78,6 +79,56 @@ data:
 
         return $true
       }
+
+      ## -------------------------------------
+      ## --------- Configure OpenSSH ---------
+      ## -------------------------------------
+
+      # OpenSSH Server is pre-installed on Windows Server 2025.
+      # Verify it exists before proceeding.
+      if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+        Write-Error "sshd service not found. This script requires a Windows Server 2025 AMI."
+        exit 1
+      }
+
+      # Start the sshd service and set it to start automatically
+      Start-Service sshd
+      Set-Service -Name sshd -StartupType 'Automatic'
+
+      # Grab the Public Key from AWS Metadata and configure authorized_keys
+      # This allows you to log in with your .pem/.ppk file instead of a password
+      $MAGIC_IP = "169.254.169.254"
+      $IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
+      $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
+
+      # Ensure SSH_PATH folder was created
+      $SSH_PATH = "C:\ProgramData\ssh"
+      Write-Host "Waiting for SSH Folder"
+      if (-not (Wait-Folder -FolderPath ${SSH_PATH})) {
+        Write-Error "Folder '${SSH_PATH}' not found! Exiting..." -ForegroundColor Red
+        exit 1
+      }
+      Write-Host "Folder '${SSH_PATH}' found"
+
+      # Add key to administrators_authorized_keys
+      $PUBKEY | Out-File -FilePath "$SSH_PATH\administrators_authorized_keys" -Encoding ascii
+
+      # Fix permissions (ACLs) for the authorized_keys file
+      # OpenSSH is strict: only System and Administrators should have access
+      $ACL = Get-Acl "$SSH_PATH\administrators_authorized_keys"
+      $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule("NT AUTHORITY\SYSTEM", "FullControl", "Allow")
+      $ACL.SetAccessRule($Ar)
+      $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Administrators", "FullControl", "Allow")
+      $ACL.SetAccessRule($Ar)
+      Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
+
+      # Restart sshd to apply key changes
+      Restart-Service sshd
+
+      # Configure the Firewall to allow SSH (Port 22)
+      Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null
+      New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -RemoteAddress any
+      Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' updated"
 
       ## -------------------------------------
       ## --------- Create Local User ---------
@@ -178,52 +229,6 @@ data:
       Add-MpPreference -ExclusionProcess "docker.exe"
       Add-MpPreference -ExclusionProcess "containerd.exe"
       Add-MpPreference -ExclusionProcess "vmcompute.exe"
-
-      ## -------------------------------------
-      ## --------- Configure OpenSSH ---------
-      ## -------------------------------------
-
-      # Install OpenSSH Server
-      Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
-
-      # Start the sshd service and set it to start automatically
-      Start-Service sshd
-      Set-Service -Name sshd -StartupType 'Automatic'
-
-      # Grab the Public Key from AWS Metadata and configure authorized_keys
-      # This allows you to log in with your .pem/.ppk file instead of a password
-      $MAGIC_IP = "169.254.169.254"
-      $IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
-      $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
-
-      # Ensure SSH_PATH folder was created
-      $SSH_PATH = "C:\ProgramData\ssh"
-      Write-Host "Waiting for SSH Folder"
-      if (-not (Wait-Folder -FolderPath ${SSH_PATH})) {
-        Write-Error "Folder '${SSH_PATH}' not found! Exiting..." -ForegroundColor Red
-        exit 1
-      }
-      Write-Host "Folder '${SSH_PATH}' found"
-
-      # Add key to administrators_authorized_keys
-      $PUBKEY | Out-File -FilePath "$SSH_PATH\administrators_authorized_keys" -Encoding ascii
-
-      # Fix permissions (ACLs) for the authorized_keys file
-      # OpenSSH is strict: only System and Administrators should have access
-      $ACL = Get-Acl "$SSH_PATH\administrators_authorized_keys"
-      $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule("NT AUTHORITY\SYSTEM", "FullControl", "Allow")
-      $ACL.SetAccessRule($Ar)
-      $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule("BUILTIN\Administrators", "FullControl", "Allow")
-      $ACL.SetAccessRule($Ar)
-      Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
-
-      # Restart sshd to apply key changes
-      Restart-Service sshd
-
-      # Configure the Firewall to allow SSH (Port 22)
-      Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' | Out-Null
-      New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -RemoteAddress any
-      Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' updated"
       </powershell>
       <persist>true</persist>
 

--- a/deploy/overlays/dev-template/host-config.yaml
+++ b/deploy/overlays/dev-template/host-config.yaml
@@ -95,11 +95,29 @@ data:
       Start-Service sshd
       Set-Service -Name sshd -StartupType 'Automatic'
 
-      # Grab the Public Key from AWS Metadata and configure authorized_keys
-      # This allows you to log in with your .pem/.ppk file instead of a password
+      # Grab the Public Key from AWS IMDS and configure authorized_keys.
+      # IMDS may not be reachable immediately during early boot, so retry.
       $MAGIC_IP = "169.254.169.254"
-      $IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
-      $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
+      $maxRetries = 30
+      $PUBKEY = $null
+      for ($i = 1; $i -le $maxRetries; $i++) {
+        try {
+          $token = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
+            -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'} `
+            -TimeoutSec 5 -ErrorAction Stop
+          $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
+            -Headers @{'X-aws-ec2-metadata-token' = $token} `
+            -TimeoutSec 5 -ErrorAction Stop
+          break
+        } catch {
+          Write-Host "IMDS request failed (attempt $i/$maxRetries): $_"
+          if ($i -eq $maxRetries) {
+            Write-Error "Failed to retrieve SSH public key from IMDS after $maxRetries attempts. Exiting."
+            exit 1
+          }
+          Start-Sleep -Seconds 2
+        }
+      }
 
       # Ensure SSH_PATH folder was created
       $SSH_PATH = "C:\ProgramData\ssh"

--- a/deploy/overlays/dev-template/host-config.yaml
+++ b/deploy/overlays/dev-template/host-config.yaml
@@ -39,7 +39,7 @@ data:
 
   dynamic.windows-c4xlarge-amd64.type: aws
   dynamic.windows-c4xlarge-amd64.region: us-east-1
-  dynamic.windows-c4xlarge-amd64.ami: ami-0cbf74fa8206e0c0f
+  dynamic.windows-c4xlarge-amd64.ami: ami-0ab5e8edee718de14
   dynamic.windows-c4xlarge-amd64.instance-type: c5.4xlarge
   dynamic.windows-c4xlarge-amd64.key-name: AWS_SSH_KEY_NAME
   dynamic.windows-c4xlarge-amd64.aws-secret: awsiam


### PR DESCRIPTION
## Summary

- Replace deregistered Windows AMI with current Server 2025 Core Base (`ami-07adb88c7ad360947`)
- The original working AMI (`ami-0cbf74fa8206e0c0f`) was **Windows Server 2025 Core Base** — not 2022
- Previous fix attempt used Server 2022 AMIs, which lack pre-installed OpenSSH. `Add-WindowsCapability -Online` fails in this VPC (no Windows Update connectivity), so SSH never came up
- Replace `Add-WindowsCapability` with an sshd existence check — OpenSSH is pre-installed on Server 2025
- Move OpenSSH configuration before user creation (correct ordering)
- Add 1200s allocation timeout for Windows (Docker CE install + potential reboot)

## Root Cause

1. AWS deregistered `ami-0cbf74fa8206e0c0f` (Server 2025 Core Base) during monthly rotation
2. Initial fix replaced with Server 2022 AMIs — a version downgrade
3. Server 2022 does not have OpenSSH pre-installed (Server 2025 does)
4. `Add-WindowsCapability -Online` requires Windows Update access to download OpenSSH, which is unavailable in this VPC
5. SSH never became available → allocation timeout → TaskRun failure

## Test plan

- [x] Confirmed original AMI was Server 2025 via git history (`fe4dcf341`, PR #10992 in infra-deployments)
- [x] Confirmed Server 2025 has OpenSSH pre-installed (Microsoft docs)
- [x] Confirmed `Add-WindowsCapability` requires Windows Update (Microsoft docs)
- [x] Looked up current Server 2025 Core Base AMI via `aws ssm get-parameter`
- [x] `make test-e2e-windows` passed in mpc_dev_env with new AMI
- [ ] CI e2e tests pass on this PR

Follow-up: update staging/production AMIs in infra-deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)