### PR TITLE
ci: lint renovate manifests

### DIFF
--- a/.github/workflows/lint-renovate.yml
+++ b/.github/workflows/lint-renovate.yml
@@ -1,0 +1,24 @@
+name: Lint renovate
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/renovate.json
+
+jobs:
+  lint-renovate:
+    name: Verify renovate manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+
+      - name: Install check-jsonschema
+        run: pipx install check-jsonschema==0.37.4
+
+      - name: Lint manifests
+        run: |
+          check-jsonschema --builtin-schema vendor.renovate .github/renovate.json


### PR DESCRIPTION
Enforce that renovate manifests follow their upstream schema.

## Summary
<!-- What does this PR do and why? Link the Jira ticket. -->

Fixes: KFLUXINFRA-4152

## Changes
<!-- Bullet list of what changed. Be specific about files/packages. -->

## Testing
<!-- How was this tested? What passed? -->
- [x] `make fmt` passes
- [x] `make lint` passes
- [x] `make test` passes
- [ ] CI checks pass (go-ci, mpc-test, test-e2e)

## Coverage
<!-- Patch coverage target: 100%. Never drop repo below 76%. -->
<!-- If >8 files changed, explain the split strategy or link paired PRs. -->

## Notes
<!-- Anything reviewers should know: trade-offs, follow-ups, risks. -->
