### PR TITLE
fix: correct variable name typo base54val -> base64val

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -52,8 +52,8 @@ func CreateEc2CloudConfig(platformName string, config map[string]string, systemN
 	userDataString := config["dynamic."+platformName+".user-data"]
 	var userDataPtr *string
 	if userDataString != "" {
-		base54val := base64.StdEncoding.EncodeToString([]byte(userDataString))
-		userDataPtr = &base54val
+		base64val := base64.StdEncoding.EncodeToString([]byte(userDataString))
+		userDataPtr = &base64val
 	}
 
 	return AWSEc2DynamicConfig{Region: config["dynamic."+platformName+".region"],

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -17,8 +17,8 @@ import (
 const systemNamespace = "multi-platform-controller"
 
 func stringEncode(s *string) *string {
-	base54val := base64.StdEncoding.EncodeToString([]byte(*s))
-	return &base54val
+	base64val := base64.StdEncoding.EncodeToString([]byte(*s))
+	return &base64val
 }
 
 var _ = Describe("Ec2 Unit Test Suit", func() {


### PR DESCRIPTION
## What
Renames the function-local variable `base54val` to `base64val` in `pkg/aws/ec2.go` and `pkg/aws/ec2_test.go`. The variable stores a base64-encoded string (`base64.StdEncoding.EncodeToString(...)`), so `base64val` matches its contents.

## Why
`base54val` is a typo — "54" instead of "64". This is a purely cosmetic rename of a function-local variable with no behavior change; existing tests are unaffected.

Fixes #987
