### PR TITLE
fix: add missing return err in checkIfIpIsLive to prevent nil pointer panic

### DIFF
--- a/pkg/ibm/ibmz_helpers.go
+++ b/pkg/ibm/ibmz_helpers.go
@@ -82,6 +82,7 @@ func checkIfIpIsLive(ctx context.Context, ip string) error {
 	server, err := net.ResolveTCPAddr("tcp", ip+":22")
 	if err != nil {
 		log.Error(err, "failed to resolve ip address")
+		return err
 	}
 	conn, err := net.DialTimeout(server.Network(), server.String(), 5*time.Second)
 	if err != nil {

--- a/pkg/ibm/ibmz_helpers_test.go
+++ b/pkg/ibm/ibmz_helpers_test.go
@@ -1,6 +1,7 @@
 package ibm
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -100,5 +101,18 @@ var _ = Describe("IBM s390x Helper Functions", func() {
 				"prod-s390x-enterprise-tag-at-validation-max45", // 45 chars - at 45 char validation limit
 				"System Z Max Tag Length"),
 		)
+	})
+
+	Describe("The checkIfIpIsLive function", func() {
+		When("the DNS resolution of the host fails", func() {
+			It("should return an error instead of panicking", func() {
+				ctx := context.Background()
+				// "a b c" contains spaces, which are invalid in DNS names
+				// — this causes net.ResolveTCPAddr to fail immediately
+				// (0ms, pure local resolution) without any network call.
+				err := checkIfIpIsLive(ctx, "a b c")
+				Expect(err).Should(HaveOccurred())
+			})
+		})
 	})
 })


### PR DESCRIPTION
@
## Summary

Fix a nil pointer dereference panic in `checkIfIpIsLive` when DNS resolution fails.

## Problem

In `pkg/ibm/ibmz_helpers.go`, the function `checkIfIpIsLive` has a missing `return` after a failed `net.ResolveTCPAddr` call. When DNS resolution fails, the error is logged but execution continues to call `server.Network()` and `server.String()` on the nil `*net.TCPAddr`, causing a panic.

## Fix

Add a `return err` after the `log.Error` call, matching the error-handling pattern used elsewhere in the same function (lines 89 and 93).

## Test

Added `checkIfIpIsLive` test that verifies DNS resolution failure returns an error rather than panicking. The test uses `"a b c"` (hostname with spaces) which causes `net.ResolveTCPAddr` to fail deterministically without any network call (0ms).

## Verification

```
go vet ./pkg/ibm/          # passes
go test ./pkg/ibm/ -v      # new test passes
```

Fixes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@