### PR TITLE
fix: correct base54val variable name to base64val in pkg/aws/ec2.go

### DIFF
--- a/pkg/aws/ec2.go
+++ b/pkg/aws/ec2.go
@@ -52,8 +52,8 @@ func CreateEc2CloudConfig(platformName string, config map[string]string, systemN
 	userDataString := config["dynamic."+platformName+".user-data"]
 	var userDataPtr *string
 	if userDataString != "" {
-		base54val := base64.StdEncoding.EncodeToString([]byte(userDataString))
-		userDataPtr = &base54val
+		base64val := base64.StdEncoding.EncodeToString([]byte(userDataString))
+		userDataPtr = &base64val
 	}
 
 	return AWSEc2DynamicConfig{Region: config["dynamic."+platformName+".region"],

--- a/pkg/aws/ec2_test.go
+++ b/pkg/aws/ec2_test.go
@@ -17,8 +17,8 @@ import (
 const systemNamespace = "multi-platform-controller"
 
 func stringEncode(s *string) *string {
-	base54val := base64.StdEncoding.EncodeToString([]byte(*s))
-	return &base54val
+	base64val := base64.StdEncoding.EncodeToString([]byte(*s))
+	return &base64val
 }
 
 var _ = Describe("Ec2 Unit Test Suit", func() {


### PR DESCRIPTION
## Summary
Fixes a variable naming typo in `pkg/aws/ec2.go`: `base54val` → `base64val`.

## The issue
The variable `base54val` is assigned the result of `base64.StdEncoding.EncodeToString(...)` but is incorrectly named `base54val` instead of `base64val`.

## Fix
Renamed the variable from `base54val` to `base64val` (2 occurrences on lines 55 and 56).

## Testing
Go compiler verified: `go build ./...`

---

Fixes #987