### PR TITLE
Add agent-config-review-required labe permissions

### DIFF
--- a/.github/workflows/agent-files-check.yaml
+++ b/.github/workflows/agent-files-check.yaml
@@ -1,12 +1,11 @@
 name: Validate PR - Agent Configuration
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
-  issues: write
 
 env:
   REVIEW_LABEL: agent-config-review-required
@@ -18,6 +17,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
 
       - name: Check for vendor-specific directories
         run: |
@@ -50,6 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
           fetch-depth: 0
 
       - name: Fetch comparison refs
@@ -98,6 +100,9 @@ jobs:
     needs: detect-protected-changes
     if: needs.detect-protected-changes.outputs.protected_changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Add review label
         if: github.event.action != 'unlabeled' && !(github.event.action == 'labeled' && github.event.label.name == env.REVIEW_LABEL)
@@ -152,6 +157,9 @@ jobs:
     needs: [detect-protected-changes, label-protected-changes]
     if: always() && (needs.detect-protected-changes.outputs.protected_changed == 'true' || needs.detect-protected-changes.result == 'failure')
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Enforce CODEOWNERS-only label removal
         if: github.event.action == 'unlabeled' && github.event.label.name == env.REVIEW_LABEL

--- a/.github/workflows/agent-files-check.yaml
+++ b/.github/workflows/agent-files-check.yaml
@@ -65,7 +65,7 @@ jobs:
 
           # Direct changes to protected paths
           for pattern in ${PROTECTED_PATHS}; do
-            DIRECT=$(git diff --name-only "${BASE_REF}..${HEAD_REF}" -- "${pattern}")
+            DIRECT=$(git diff --no-ext-diff --name-only "${BASE_REF}..${HEAD_REF}" -- "${pattern}")
             if [ -n "${DIRECT}" ]; then
               PROTECTED_CHANGED="${PROTECTED_CHANGED}\n${DIRECT}"
             fi
@@ -75,7 +75,7 @@ jobs:
           for path in ${PROTECTED_PATHS}; do
             CLEAN_PATH="${path%/}"
             ESCAPED_PATH=$(printf '%s' "${CLEAN_PATH}" | sed 's/[.[\^$*+?()|{}]/\\&/g')
-            if git diff "${BASE_REF}..${HEAD_REF}" | grep -qE "(>>?[[:space:]]*['\"]?${ESCAPED_PATH}|cp[[:space:]]+.*${ESCAPED_PATH}|mv[[:space:]]+.*${ESCAPED_PATH}|tee[[:space:]]+.*${ESCAPED_PATH}|sed[[:space:]]+.*-i.*${ESCAPED_PATH})"; then
+            if git diff --no-ext-diff "${BASE_REF}..${HEAD_REF}" | grep -qE "(>>?[[:space:]]*['\"]?${ESCAPED_PATH}|cp[[:space:]]+.*${ESCAPED_PATH}|mv[[:space:]]+.*${ESCAPED_PATH}|tee[[:space:]]+.*${ESCAPED_PATH}|sed[[:space:]]+.*-i.*${ESCAPED_PATH})"; then
               PROTECTED_CHANGED="${PROTECTED_CHANGED}\nIndirect write to ${CLEAN_PATH} detected in diff"
             fi
           done


### PR DESCRIPTION

## Summary
Update agent files CI checks to be able to create and add the agent-config-review-required label from fork PRs
Resolves: [KFLUXINFRA-4253](https://redhat.atlassian.net/browse/KFLUXINFRA-4253)

## Changes
1. Added `write` permissions only when needed
2. Changed the CI to have the upstream CI privileges and not the fork privileges.
## Testing
- [x] Test it on a private fork (done)
- [ ] Open a follow-up PR and see if it has the label when needed



[KFLUXINFRA-4253]: https://redhat.atlassian.net/browse/KFLUXINFRA-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ