### PR TITLE
KFLUXINFRA-4352 fixing gaps in agent files defense 

### DIFF
--- a/.github/workflows/agent-files-detect.yaml
+++ b/.github/workflows/agent-files-detect.yaml
@@ -35,7 +35,7 @@ jobs:
             if [ -d "${match}" ]; then
               ls -la "${match}/"
             fi
-          done < <(find . -path ./.git -prune -o \( -name '.claude' -o -name '.cursor' \) -print0)
+          done < <(find . -path ./.git -prune -o \( -name '.claude' -o -name '.cursor' -o -name '.vscode' -o -name '.agents' \) -print0)
           if [ "${FOUND}" -eq 1 ]; then
             exit 1
           fi
@@ -76,7 +76,7 @@ jobs:
             sanitized="${sanitized//$'\n'/'%0A'}"
             sanitized="${sanitized//$'\r'/'%0D'}"
             echo "::warning::Protected agent files changed: ${sanitized}"
-          elif git diff --no-ext-diff "${BASE_SHA}..${HEAD_SHA}" | grep -qiE 'AGENTS\.md|CLAUDE\.md|GEMINI\.md|\.claude|\.cursor|\.agents|skills/'; then
+          elif git diff --no-ext-diff "${BASE_SHA}..${HEAD_SHA}" | grep -qiE 'AGENTS\.md|CLAUDE\.md|GEMINI\.md|\.claude|\.cursor|\.vscode|\.agents|skills/'; then
             echo "protected_changed=true" >> "${GITHUB_OUTPUT}"
             echo "::warning::Reference to protected path found in diff"
           else

--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -198,7 +198,7 @@ jobs:
             try {
               const membership = await github.rest.teams.getMembershipForUserInOrg({
                 org: context.repo.owner,
-                team_slug: 'konflux-infra-team',
+                team_slug: 'infrastructure',
                 username: sender,
               });
               isMember = membership.data.state === 'active';
@@ -227,7 +227,7 @@ jobs:
                 labels: [label],
               });
               core.warning(
-                `User '${sender}' is not a member of konflux-infra-team. Label '${label}' has been re-added. Only infra-team reviewers can remove this label.`
+                `User '${sender}' is not a member of infrastructure. Label '${label}' has been re-added. Only infra-team reviewers can remove this label.`
               );
             }
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ target
 .settings
 .project
 .classpath
-.vscode/
 .tmp
 *~
 local-test
@@ -45,3 +44,9 @@ deploy/**/development/**
 
 # testing outputs
 test-report.json
+
+# Agent security
+.claude/
+.cursor/
+.agents/
+.vscode/


### PR DESCRIPTION
## Summary
fixing gaps in agent files defense that was found during manual testing - add vendor specific folders to gitignore, fix the team Github slug and include also .vscode/ as a potential attack vector

Resolves: [KFLUXINFRA-4352](https://redhat.atlassian.net/browse/KFLUXINFRA-4352)

## Changes
- Add agent security sensitive folders folders to `.gitignore`
- Changed Github team's slug from `konflux-infra-team` to `infrastructure`
- Added `.vscode/` and `.agents/` for the `Check for vendor-specific directories` check

## Testing
- [x] automated tests passed
- [x] `gh api orgs/konflux-ci/teams/infrastructure` returns our team members while `gh api orgs/konflux-ci/teams/konflux-infra-team` returns `404`
- [x] CI checks pass (go-ci, mpc-test, test-e2e)



[KFLUXINFRA-4352]: https://redhat.atlassian.net/browse/KFLUXINFRA-4352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ