### PR TITLE
fix: add missing return err after failed ResolveTCPAddr in checkIfIpIsLive

### DIFF
--- a/pkg/ibm/ibmz_helpers.go
+++ b/pkg/ibm/ibmz_helpers.go
@@ -82,6 +82,7 @@ func checkIfIpIsLive(ctx context.Context, ip string) error {
 	server, err := net.ResolveTCPAddr("tcp", ip+":22")
 	if err != nil {
 		log.Error(err, "failed to resolve ip address")
+		return err
 	}
 	conn, err := net.DialTimeout(server.Network(), server.String(), 5*time.Second)
 	if err != nil {


### PR DESCRIPTION
## Bug Description
In `pkg/ibm/ibmz_helpers.go`, the function `checkIfIpIsLive` has a missing `return` statement after a failed `net.ResolveTCPAddr` call. When DNS resolution fails, the error is logged but execution continues to line 86, where `server.Network()` and `server.String()` are called on a nil `net.TCPAddr`, causing a nil pointer panic.

## Fix
Add `return err` after the error log on line 84, matching the error-handling pattern used elsewhere in the same function (see lines 89 and 93).

## Impact
Any DNS resolution failure for an IBM Z or IBM Power host IP address will crash the controller with a nil pointer dereference panic rather than returning a clean error to the caller.

---
Fixes #985