### PR TITLE
Pin kindest/node image by digest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -112,7 +112,7 @@
         ".github/workflows/**"
       ],
       "matchStrings": [
-        "kindest/node:(?<currentValue>v[^\\s#]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
+        "kindest/node:(?<currentValue>v[^@\\s#]+)@(?<currentDigest>sha256:[a-f0-9]+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)"
       ]
     }
   ]

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -83,7 +83,7 @@ jobs:
         run: kind version
 
       - name: Create kind cluster
-        run: kind create cluster --image kindest/node:v1.35.5 # renovate: datasource=docker depName=kindest/node versioning=docker
+        run: kind create cluster --image kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95 # renovate: datasource=docker depName=kindest/node versioning=docker
 
       - name: Build and load images
         env:


### PR DESCRIPTION
## Summary
- Pin `kindest/node:v1.35.5` to its SHA256 manifest digest (`@sha256:ce977ae6...`) for supply-chain integrity
- Update Renovate regex custom manager to capture `currentDigest`, so tag and digest are updated together on version bumps

## Context
Follow-up to #995 and aligning with the same change in tekton-keue [as requested by Andy](https://github.com/tektoncd/tekton-kueue/pull/522#discussion_r3731267433). Digest pinning ensures the exact image is used even if the tag is re-pushed upstream. Renovate's regex manager cannot perform initial pinning ([renovatebot/renovate#10993](https://github.com/renovatebot/renovate/issues/10993)), so the digest is added manually here; Renovate maintains it going forward.

## Test plan
- [ ] E2E tests pass with digest-pinned image (CI validates this)
- [ ] Renovate validates the updated regex (lint-renovate workflow)

Relates to: [KFLUXINFRA-4335](https://redhat.atlassian.net/browse/KFLUXINFRA-4335)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXINFRA-4335]: https://redhat.atlassian.net/browse/KFLUXINFRA-4335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ