### PR TITLE
KFLUXINFRA-4473 Limit agent-config-review-required label to ignore PR history

### DIFF
--- a/.github/workflows/agent-files-detect.yaml
+++ b/.github/workflows/agent-files-detect.yaml
@@ -43,8 +43,12 @@ jobs:
           echo "No vendor-specific directories found."
 
   # Diffs the PR for changes to protected agent files (direct and indirect).
-  # On synchronize, only diffs the new push so approved changes don't re-trigger.
-  # Uploads result as artifact for the enforce workflow.
+  # Computes two independent results:
+  #   - protected_changed (incremental): on synchronize, only the new push (before..after),
+  #     so previously-reviewed changes don't re-trigger labeling. Drives the ADD decision.
+  #   - net_protected_changed (net): the PR's current state vs. base (base...head), so a PR
+  #     that reverted its agent-file edits reads as clean. Drives the REMOVE decision.
+  # Uploads both results as an artifact for the enforce workflow.
   # Skipped for merge_group — PR-level enforcement already ran.
   detect-protected-changes:
     if: github.event_name != 'merge_group'
@@ -59,44 +63,78 @@ jobs:
 
       - name: Fetch comparison refs
         env:
-          BASE_REF: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha }}
-          HEAD_REF: ${{ github.event.action == 'synchronize' && github.event.after || github.event.pull_request.head.sha }}
-        run: git fetch --depth=1 origin "${BASE_REF}" "${HEAD_REF}"
+          INC_BASE_REF: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha }}
+          INC_HEAD_REF: ${{ github.event.action == 'synchronize' && github.event.after || github.event.pull_request.head.sha }}
+          NET_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          NET_HEAD_REF: ${{ github.event.pull_request.head.sha }}
+        # No --depth: the three-dot net diff needs the merge-base, which a shallow
+        # fetch may not include. The checkout above is already full (fetch-depth: 0).
+        run: git fetch origin "${INC_BASE_REF}" "${INC_HEAD_REF}" "${NET_BASE_REF}" "${NET_HEAD_REF}"
 
       - name: Check for protected file changes
         id: check
         env:
-          BASE_SHA: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.action == 'synchronize' && github.event.after || github.event.pull_request.head.sha }}
+          INC_BASE_SHA: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha }}
+          INC_HEAD_SHA: ${{ github.event.action == 'synchronize' && github.event.after || github.event.pull_request.head.sha }}
+          NET_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          NET_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          ALL_CHANGED=$(git diff --no-ext-diff --name-only "${BASE_SHA}..${HEAD_SHA}")
+          # Sets RANGE_RESULT ("true"/"false") for whether the given diff range touches
+          # protected agent files (direct path match) or references a protected path
+          # (indirect heuristic). Also sets DIRECT_MATCH to the matched paths, if any.
+          # Called directly (not via $(...)) so the globals propagate.
+          # $1 = diff range expression (e.g. "A..B" incremental or "A...B" net)
+          check_range() {
+            local range="$1"
+            local changed
+            changed=$(git diff --no-ext-diff --name-only "${range}")
+            DIRECT_MATCH=$(echo "${changed}" | grep -E '(^|/)(AGENTS\.md|CLAUDE\.md|GEMINI\.md)$|(^|/)skills/|^\.github/workflows/agent-files-(detect|enforce)\.yaml$' || true)
+            if [ -n "${DIRECT_MATCH}" ]; then
+              RANGE_RESULT="true"
+            elif git diff --no-ext-diff "${range}" | grep -qiE 'AGENTS\.md|CLAUDE\.md|GEMINI\.md|\.claude|\.cursor|\.vscode|\.agents|skills/'; then
+              RANGE_RESULT="true"
+            else
+              RANGE_RESULT="false"
+            fi
+          }
 
-          DIRECT=$(echo "${ALL_CHANGED}" | grep -E '(^|/)(AGENTS\.md|CLAUDE\.md|GEMINI\.md)$|(^|/)skills/|^\.github/workflows/agent-files-(detect|enforce)\.yaml$' || true)
-          if [ -n "${DIRECT}" ]; then
-            echo "protected_changed=true" >> "${GITHUB_OUTPUT}"
-            sanitized="${DIRECT//'%'/'%25'}"
+          # Incremental (ADD signal) — two-dot, only the new push on synchronize.
+          check_range "${INC_BASE_SHA}..${INC_HEAD_SHA}"
+          INCREMENTAL="${RANGE_RESULT}"
+          if [ "${INCREMENTAL}" = "true" ] && [ -n "${DIRECT_MATCH}" ]; then
+            sanitized="${DIRECT_MATCH//'%'/'%25'}"
             sanitized="${sanitized//'::'/'%3A%3A'}"
             sanitized="${sanitized//$'\n'/'%0A'}"
             sanitized="${sanitized//$'\r'/'%0D'}"
-            echo "::warning::Protected agent files changed: ${sanitized}"
-          elif git diff --no-ext-diff "${BASE_SHA}..${HEAD_SHA}" | grep -qiE 'AGENTS\.md|CLAUDE\.md|GEMINI\.md|\.claude|\.cursor|\.vscode|\.agents|skills/'; then
-            echo "protected_changed=true" >> "${GITHUB_OUTPUT}"
-            echo "::warning::Reference to protected path found in diff"
-          else
-            echo "protected_changed=false" >> "${GITHUB_OUTPUT}"
-            echo "No protected agent files affected."
+            echo "::warning::Protected agent files changed in latest push: ${sanitized}"
+          elif [ "${INCREMENTAL}" = "true" ]; then
+            # Flagged by the indirect heuristic (no direct path match). Keep the message
+            # generic — the diff content is attacker-influenced, so don't echo it.
+            echo "::warning::Latest push indirectly references a protected agent path (e.g. a script writing to AGENTS.md/CLAUDE.md/GEMINI.md/skills/ or a vendor keyword in the diff)."
           fi
+
+          # Net (REMOVE signal) — three-dot, the PR's current state vs. base.
+          check_range "${NET_BASE_SHA}...${NET_HEAD_SHA}"
+          NET="${RANGE_RESULT}"
+
+          echo "protected_changed=${INCREMENTAL}" >> "${GITHUB_OUTPUT}"
+          echo "net_protected_changed=${NET}" >> "${GITHUB_OUTPUT}"
+          echo "Incremental protected change: ${INCREMENTAL}; net protected change: ${NET}"
 
       - name: Write detection result
         env:
           PROTECTED_CHANGED: ${{ steps.check.outputs.protected_changed }}
-        run: echo "${PROTECTED_CHANGED}" > /tmp/agent-check-result.txt
+          NET_PROTECTED_CHANGED: ${{ steps.check.outputs.net_protected_changed }}
+        run: |
+          mkdir -p /tmp/agent-detect
+          echo "${PROTECTED_CHANGED}" > /tmp/agent-detect/agent-check-result.txt
+          echo "${NET_PROTECTED_CHANGED}" > /tmp/agent-detect/agent-net-result.txt
 
       - name: Upload detection result
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: agent-check-result
-          path: /tmp/agent-check-result.txt
+          path: /tmp/agent-detect/
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -53,7 +53,7 @@ jobs:
       actions: write
       pull-requests: write
     outputs:
-      protected_changed: ${{ steps.decide.outputs.protected_changed }}
+      label_action: ${{ steps.decide.outputs.label_action }}
     steps:
       # The detect workflow runs PR code (pull_request trigger), so if the PR modifies
       # the workflow files, the artifact cannot be trusted. Check independently via API.
@@ -88,24 +88,49 @@ jobs:
       - name: Decide detection result
         id: decide
         run: |
+          # Reads a validated boolean from an artifact file. Prints "true"/"false" on
+          # success; on missing/invalid content prints "invalid" (caller fails closed).
+          read_bool() {
+            local file="$1" value
+            if [ ! -f "${file}" ]; then
+              echo "invalid"
+              return
+            fi
+            value=$(tr -d '[:space:]' < "${file}")
+            if [ "${value}" != "true" ] && [ "${value}" != "false" ]; then
+              echo "invalid"
+              return
+            fi
+            echo "${value}"
+          }
+
           # If workflow files were changed, always flag — regardless of artifact content.
+          # (The detect workflow runs PR code, so a tampered artifact cannot be trusted.)
           if [ "${{ steps.workflow-check.outputs.changed }}" = "true" ]; then
             echo "Workflow files modified — flagging for review."
-            echo "protected_changed=true" >> "${GITHUB_OUTPUT}"
+            echo "label_action=add" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          # Otherwise trust the artifact (preserves incremental diff behavior).
-          if [ -f /tmp/detect-result/agent-check-result.txt ]; then
-            RESULT=$(tr -d '[:space:]' < /tmp/detect-result/agent-check-result.txt)
-            if [ "${RESULT}" != "true" ] && [ "${RESULT}" != "false" ]; then
-              echo "::error::Invalid artifact value: '${RESULT}'. Failing closed."
-              echo "protected_changed=true" >> "${GITHUB_OUTPUT}"
-              exit 0
-            fi
-            echo "protected_changed=${RESULT}" >> "${GITHUB_OUTPUT}"
+
+          INCREMENTAL=$(read_bool /tmp/detect-result/agent-check-result.txt)
+          NET=$(read_bool /tmp/detect-result/agent-net-result.txt)
+
+          # Fail closed on any missing/invalid artifact value.
+          if [ "${INCREMENTAL}" = "invalid" ] || [ "${NET}" = "invalid" ]; then
+            echo "::error::Detection artifact missing or invalid. Failing closed."
+            echo "label_action=add" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # ADD on new agent changes in the latest push (incremental); REMOVE when the
+          # PR's current state is clean (net=false); otherwise leave the label as-is so a
+          # reviewer's approval-removal survives unrelated pushes.
+          if [ "${NET}" = "false" ]; then
+            echo "label_action=remove" >> "${GITHUB_OUTPUT}"
+          elif [ "${INCREMENTAL}" = "true" ]; then
+            echo "label_action=add" >> "${GITHUB_OUTPUT}"
           else
-            echo "::error::Detection artifact missing. Failing closed."
-            echo "protected_changed=true" >> "${GITHUB_OUTPUT}"
+            echo "label_action=neutral" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Delete detection artifact
@@ -129,7 +154,7 @@ jobs:
             }
 
       - name: Add review label
-        if: steps.decide.outputs.protected_changed == 'true'
+        if: steps.decide.outputs.label_action == 'add'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
@@ -179,6 +204,32 @@ jobs:
               }
             }
 
+      # Remove the label when the PR's current (net) state no longer touches protected
+      # agent files — e.g. the PR reverted its earlier agent-file changes.
+      - name: Remove review label
+        if: steps.decide.outputs.label_action == 'remove'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        with:
+          script: |
+            const label = process.env.REVIEW_LABEL;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label,
+              });
+              core.info(`Removed '${label}' label — PR no longer changes protected agent files.`);
+            } catch (e) {
+              // 404 = label not present on the PR (nothing to remove).
+              if (e.status !== 404) {
+                core.setFailed(`Failed to remove label '${label}': ${e.message}`);
+              }
+            }
+
   block-on-label:
     name: Block PR if review label is present
     # Only run for workflow_run or our specific label — skip unrelated label events (lgtm, approved, etc.)
@@ -213,7 +264,7 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           LABEL_JOB_RESULT: ${{ needs.label-protected-changes.result }}
-          PROTECTED_CHANGED: ${{ needs.label-protected-changes.outputs.protected_changed }}
+          LABEL_ACTION: ${{ needs.label-protected-changes.outputs.label_action }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -267,7 +318,10 @@ jobs:
               core.setFailed(
                 `PR has '${label}' label. A reviewer with write access must review the agent config changes and remove this label before merging.`
               );
-            } else if (context.eventName === 'workflow_run' && process.env.PROTECTED_CHANGED === 'true') {
+            } else if (context.eventName === 'workflow_run' && process.env.LABEL_ACTION === 'add') {
+              // We intended to add the label but it isn't present — the add step failed.
+              // (A legitimate approved PR reads as 'neutral'/'remove', not 'add', so it is
+              // not blocked here.)
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
Two-workflow architecture (GitHub):
- agent-files-detect.yaml (pull_request): block-vendor-dirs, detect-protected-changes, upload artifact
- agent-files-enforce.yaml (workflow_run + pull_request_target): label-protected-changes, enforce label removal, block merge while label is present

## Summary
<!-- What does this PR do and why? Link the Jira ticket. -->
Limits the `agent-config-review-required` label to the PR's **current net state** instead of its
push history.

Resolves: [KFLUXINFRA-4473](https://redhat.atlassian.net/browse/KFLUXINFRA-4473)

## Changes
<!-- Bullet list of what changed. Be specific about files/packages. -->
- `.github/workflows/agent-files-detect.yaml`: compute both incremental (`before..after`) and net (`base...head`) results; upload both in the detection artifact.
- `.github/workflows/agent-files-enforce.yaml`: derive `label_action` (add/remove/neutral) — add-on-incremental, remove-on-net-clean, fail-closed to add on invalid.


## Testing
<!-- How was this tested? What passed? -->
- [x] `tests/run-tests.sh` live e2e suite passes against a fork PR (all 26 steps, incl. the new revert
  scenario and the incremental approval-persistence steps 18/19/23)
- [x] `actionlint` clean on both GitHub workflow files
- [x] Manual QA on a private fork, end-to-end on one PR:
  1. Branched from `main` *before* the agent-files changes existed there, added an unrelated change → no label
  2. Merged `main` in (which by then carried agent-file changes) → label **not** triggered, confirming the
     net diff (`base...head`) ignores agent changes coming from the base branch, only the PR's own
  3. Added a commit that changes a protected agent file → label **added**, merge blocked
  4. Added a commit reverting that change → label **removed**, merge unblocked

## Notes
- The merge-queue workaround job in the real repos is preserved.


[KFLUXINFRA-4473]: https://redhat.atlassian.net/browse/KFLUXINFRA-4473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ