### PR TITLE
fix: return after DNS resolve failure in checkIfIpIsLive

### DIFF
--- a/pkg/ibm/ibmz_helpers.go
+++ b/pkg/ibm/ibmz_helpers.go
@@ -82,6 +82,7 @@ func checkIfIpIsLive(ctx context.Context, ip string) error {
 	server, err := net.ResolveTCPAddr("tcp", ip+":22")
 	if err != nil {
 		log.Error(err, "failed to resolve ip address")
+		return err
 	}
 	conn, err := net.DialTimeout(server.Network(), server.String(), 5*time.Second)
 	if err != nil {


### PR DESCRIPTION
## Summary

fix: return after DNS resolve failure in checkIfIpIsLive

## Changes

- Missing return after ResolveTCPAddr error led to nil pointer panic on DialTimeout.

Fixes #985
