### PR TITLE
Fix .gitignore to ignore agent config symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ deploy/**/development/**
 test-report.json
 
 # Agent security
-.claude/
-.cursor/
-.agents/
-.vscode/
+.claude
+.cursor
+.agents
+.vscode


### PR DESCRIPTION
## Summary

The `.claude`, `.cursor`, `.agents`, and `.vscode` entries in `.gitignore` had trailing slashes, which only match directories. `.claude` is a symlink (git treats symlinks as files), so it slipped past the ignore rule and got committed. Dropping the trailing slashes makes the patterns match files and symlinks too.

## Test plan

- Verified `git check-ignore .claude` now matches the symlink.