### PR TITLE
Allow dependencies updates by bots to ignore agent-defense checks

### DIFF
--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -75,6 +75,51 @@ jobs:
             );
             core.setOutput('changed', changed.toString());
 
+      # Skip labeling for PRs opened by trusted bots (Dependabot, Konflux). Identity is
+      # taken from the GitHub API (pull_request.user), never from spoofable commit metadata,
+      # and pinned by account id so a renamed/reused login can't impersonate. Every commit
+      # must also be verified-signed by that bot, so a write-access insider can't sneak an
+      # unsigned/human commit onto a bot PR to ride the skip.
+      - name: Check for trusted bot author
+        id: bot-check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        with:
+          script: |
+            // login -> id. Match BOTH; type must be "Bot".
+            const TRUSTED_BOTS = {
+              'dependabot[bot]': 49699333,
+              'red-hat-konflux[bot]': 126015336,
+            };
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const u = pr.user || {};
+            const isTrustedOpener =
+              u.type === 'Bot' &&
+              Object.prototype.hasOwnProperty.call(TRUSTED_BOTS, u.login) &&
+              TRUSTED_BOTS[u.login] === u.id;
+
+            let trusted = false;
+            if (isTrustedOpener) {
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              // Every commit must be verified-signed AND authored by the same bot account.
+              trusted = commits.length > 0 && commits.every(c =>
+                c.commit?.verification?.verified === true &&
+                c.author && c.author.id === u.id
+              );
+            }
+            console.log(`PR opener: ${u.login} (id ${u.id}, type ${u.type}); trusted_bot=${trusted}`);
+            core.setOutput('trusted_bot', trusted.toString());
+
       - name: Download detection artifact
         id: download
         continue-on-error: true
@@ -103,6 +148,13 @@ jobs:
             fi
             echo "${value}"
           }
+
+          # Trusted bot (verified identity + all commits verified-signed): never label.
+          if [ "${{ steps.bot-check.outputs.trusted_bot }}" = "true" ]; then
+            echo "PR opened by a trusted bot — skipping label."
+            echo "label_action=remove" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
 
           # If workflow files were changed, always flag — regardless of artifact content.
           # (The detect workflow runs PR code, so a tampered artifact cannot be trusted.)


### PR DESCRIPTION
## Summary
Ignore the agent files defense checks for dependabot and red-hat-konflux to make them update the github action dependencies without agent label blocking them

## Changes
<!-- Bullet list of what changed. Be specific about files/packages. -->
- `.github/workflows/agent-files-enforce.yaml`:
  - New `bot-check` step (github-script) that decides whether the PR was opened by a trusted bot.
    Identity is read from the GitHub API (`pull_request.user`), never from commit metadata, and
    matched on `login` **and** account `id` with `type == "Bot"`. Additionally, every commit must
    be verified-signed and authored by that same bot account.
  - `decide` step short-circuits to `label_action=remove` (skip labeling) when `bot-check` returns
    trusted, before the artifact/tamper logic runs.
- Hardcoded allowlist: `dependabot[bot]` (id `49699333`), `red-hat-konflux[bot]` (id `126015336`).

## Testing / Validation
<!-- How was this tested? What passed? -->
- Verified the hardcoded bot identities against the GitHub API:
  ```bash
  gh api /users/dependabot%5Bbot%5D --jq '{login,id,type}'
  # {"login":"dependabot[bot]","id":49699333,"type":"Bot"}
  gh api /users/red-hat-konflux%5Bbot%5D --jq '{login,id,type}'
  # {"login":"red-hat-konflux[bot]","id":126015336,"type":"Bot"}
