### PR TITLE
Fix stale artifact race and rename bypass in agent-files workflows

### DIFF
--- a/.github/workflows/agent-files-detect.yaml
+++ b/.github/workflows/agent-files-detect.yaml
@@ -86,9 +86,22 @@ jobs:
           # $1 = diff range expression (e.g. "A..B" incremental or "A...B" net)
           check_range() {
             local range="$1"
-            local changed
-            changed=$(git diff --no-ext-diff --name-only "${range}")
-            DIRECT_MATCH=$(echo "${changed}" | grep -E '(^|/)(AGENTS\.md|CLAUDE\.md|GEMINI\.md)$|(^|/)skills/|^\.github/workflows/agent-files-(detect|enforce)\.yaml$' || true)
+            local changed all_paths
+            # Use --name-status to catch renames/deletes (exposes old path via R/D status lines).
+            # Format: "A\tpath", "M\tpath", "R100\told\tnew", "D\tpath"
+            changed=$(git diff --no-ext-diff --name-status "${range}")
+            # Extract all paths (both old and new for renames) to check against protected patterns.
+            all_paths=$(echo "${changed}" | awk '{
+              if ($1 ~ /^R/) {
+                # Rename: $2 = old path, $3 = new path
+                print $2
+                print $3
+              } else {
+                # Add/Modify/Delete: $2 = path
+                print $2
+              }
+            }')
+            DIRECT_MATCH=$(echo "${all_paths}" | grep -E '(^|/)(AGENTS\.md|CLAUDE\.md|GEMINI\.md)$|(^|/)skills/|^\.github/workflows/agent-files-(detect|enforce)\.yaml$' || true)
             if [ -n "${DIRECT_MATCH}" ]; then
               RANGE_RESULT="true"
             elif git diff --no-ext-diff "${range}" | grep -qiE 'AGENTS\.md|CLAUDE\.md|GEMINI\.md|\.claude|\.cursor|\.vscode|\.agents|skills/'; then

--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -69,9 +69,13 @@ jobs:
               repo: context.repo.repo,
               pull_number: parseInt(process.env.PR_NUMBER, 10),
             });
+            const workflowPaths = [
+              '.github/workflows/agent-files-detect.yaml',
+              '.github/workflows/agent-files-enforce.yaml'
+            ];
             const changed = files.some(f =>
-              f.filename === '.github/workflows/agent-files-detect.yaml' ||
-              f.filename === '.github/workflows/agent-files-enforce.yaml'
+              workflowPaths.includes(f.filename) ||
+              (f.previous_filename && workflowPaths.includes(f.previous_filename))
             );
             core.setOutput('changed', changed.toString());
 
@@ -120,6 +124,32 @@ jobs:
             console.log(`PR opener: ${u.login} (id ${u.id}, type ${u.type}); trusted_bot=${trusted}`);
             core.setOutput('trusted_bot', trusted.toString());
 
+      # Verify workflow run head matches current PR head. If the PR was force-pushed or
+      # received new commits after the detect workflow started, the artifact is stale and
+      # must not be used to mutate labels or post status (would incorrectly approve/block
+      # a different commit than what the artifact describes).
+      - name: Verify artifact freshness
+        id: freshness-check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const workflowRunHeadSha = process.env.WORKFLOW_RUN_HEAD_SHA;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const currentHeadSha = pr.head.sha;
+            const fresh = workflowRunHeadSha === currentHeadSha;
+            if (!fresh) {
+              console.log(`Stale artifact detected: workflow run analyzed ${workflowRunHeadSha.substring(0,7)} but PR head is now ${currentHeadSha.substring(0,7)}. Skipping label mutation.`);
+            }
+            core.setOutput('fresh', fresh.toString());
+
       - name: Download detection artifact
         id: download
         continue-on-error: true
@@ -148,6 +178,14 @@ jobs:
             fi
             echo "${value}"
           }
+
+          # Stale artifact: the workflow run analyzed a different commit than the PR's
+          # current head. Do not mutate labels (a newer detect run may already be queued).
+          if [ "${{ steps.freshness-check.outputs.fresh }}" != "true" ]; then
+            echo "Artifact is stale — skipping label mutation."
+            echo "label_action=neutral" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
 
           # Trusted bot (verified identity + all commits verified-signed): never label.
           if [ "${{ steps.bot-check.outputs.trusted_bot }}" = "true" ]; then

--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -375,7 +375,8 @@ jobs:
               // Skip stale runs: artifact analyzed a different commit than PR's current head.
               // A newer detect run will handle the current head; this stale run must not
               // publish a status for a commit it didn't analyze.
-              if (process.env.FRESH !== 'true') {
+              // Only skip on explicit fresh==='false'; if missing/undefined, fail closed below.
+              if (process.env.FRESH === 'false') {
                 console.log(`Skipping status for stale run (analyzed ${targetSha.substring(0,7)} but PR head has moved). A newer detect run will evaluate current head.`);
                 return;
               }

--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -54,6 +54,7 @@ jobs:
       pull-requests: write
     outputs:
       label_action: ${{ steps.decide.outputs.label_action }}
+      fresh: ${{ steps.freshness-check.outputs.fresh }}
     steps:
       # The detect workflow runs PR code (pull_request trigger), so if the PR modifies
       # the workflow files, the artifact cannot be trusted. Check independently via API.
@@ -355,6 +356,8 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           LABEL_JOB_RESULT: ${{ needs.label-protected-changes.result }}
           LABEL_ACTION: ${{ needs.label-protected-changes.outputs.label_action }}
+          FRESH: ${{ needs.label-protected-changes.outputs.fresh }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -362,19 +365,28 @@ jobs:
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const statusContext = 'Agent File Policy';
 
-            // Fail-closed: if label management job didn't succeed, block the PR
+            // For workflow_run events, bind status to the analyzed SHA (workflow_run.head_sha),
+            // not a re-fetched pr.head.sha which may have changed since detection ran.
+            // For pull_request_target events (label changes), fetch current head.
+            let targetSha;
             if (context.eventName === 'workflow_run') {
+              targetSha = process.env.WORKFLOW_RUN_HEAD_SHA;
+
+              // Skip stale runs: artifact analyzed a different commit than PR's current head.
+              // A newer detect run will handle the current head; this stale run must not
+              // publish a status for a commit it didn't analyze.
+              if (process.env.FRESH !== 'true') {
+                console.log(`Skipping status for stale run (analyzed ${targetSha.substring(0,7)} but PR head has moved). A newer detect run will evaluate current head.`);
+                return;
+              }
+
+              // Fail-closed: if label management job didn't succeed, block the PR
               const labelJobResult = process.env.LABEL_JOB_RESULT;
               if (labelJobResult !== 'success') {
-                const pr = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                });
                 await github.rest.repos.createCommitStatus({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  sha: pr.data.head.sha,
+                  sha: targetSha,
                   state: 'failure',
                   context: statusContext,
                   description: `Label management did not succeed (${labelJobResult}). Blocking PR.`,
@@ -382,13 +394,16 @@ jobs:
                 core.setFailed(`Label management job did not succeed (${labelJobResult}). Blocking the PR.`);
                 return;
               }
+            } else {
+              // pull_request_target event: fetch current head for label-triggered re-evaluation
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              targetSha = pr.data.head.sha;
             }
 
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
             const labels = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -400,7 +415,7 @@ jobs:
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                sha: pr.data.head.sha,
+                sha: targetSha,
                 state: 'failure',
                 context: statusContext,
                 description: `PR has '${label}' label — write-access review required.`,
@@ -415,7 +430,7 @@ jobs:
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                sha: pr.data.head.sha,
+                sha: targetSha,
                 state: 'failure',
                 context: statusContext,
                 description: 'Protected changes detected but label was not applied. Blocking PR.',
@@ -425,7 +440,7 @@ jobs:
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                sha: pr.data.head.sha,
+                sha: targetSha,
                 state: 'success',
                 context: statusContext,
                 description: 'No agent config review required.',


### PR DESCRIPTION
Two security fixes for agent-files-defense workflows:

## 1. Stale Artifact Race

**Problem:** Enforce workflow doesn't verify analyzed commit matches current PR head. Force-push between detect and enforce can cause stale results to label/approve wrong commit.

**Fix:**
- Freshness check: compare `workflow_run.head_sha` vs `pr.head.sha`
- Skip stale runs: don't mutate labels or post status when mismatch
- Bind status to analyzed SHA: use `workflow_run.head_sha` not re-fetched `pr.head.sha`
- Fail-closed: treat undefined freshness as error, not stale

## 2. Workflow Rename Bypass

**Problem:** `git diff --name-only` only shows destination paths. Renaming workflow to `.disabled` bypasses detection.

**Fix:**
- Detect: `--name-status` extracts old + new paths from renames
- Enforce: check `previous_filename` in GitHub API

## Testing
Manual and automated tests passed.

Related: KFLUXINFRA-4254